### PR TITLE
Add support for minReadySeconds to ValkeyCluster CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ $ dagger call build-and-load-locally --sock /var/run/docker.sock
   ): Void 32.6s
 ```
 
+> [!WARNING]
+> Make sure that you don't run `make test-e2e` instead as it will generate binaries specific to your platform (in `bin`) and will also load the built image into Docker, instead of into your kind cluster.
+
 Once done, you'll want to execute the following command to run the e2e test suite:
 
 ```console

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -55,6 +55,16 @@ type ValkeyClusterSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Storage *corev1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
 
+	// An optional field that specifies the minimum number of seconds for which a
+	// newly created Pod should be ready without any of its containers crashing, for
+	// it to be considered available.
+	// This defaults to 0 (the Pod will be considered available as soon as it is ready).
+	//
+	// NOTE: If support for `progressDeadlineSeconds` is added in future, it must be
+	// greater than `minReadySeconds` if `minReadySeconds` is specified.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
+
 	// Tolerations
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -63,6 +63,7 @@ type ValkeyClusterSpec struct {
 	// NOTE: If support for `progressDeadlineSeconds` is added in future, it must be
 	// greater than `minReadySeconds` if `minReadySeconds` is specified.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default=10
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
 	// Tolerations

--- a/config/crd/bases/cache.halter.io_valkeyclusters.yaml
+++ b/config/crd/bases/cache.halter.io_valkeyclusters.yaml
@@ -50,6 +50,7 @@ spec:
                 description: Valkey docker image to use
                 type: string
               minReadySeconds:
+                default: 10
                 description: |-
                   An optional field that specifies the minimum number of seconds for which a
                   newly created Pod should be ready without any of its containers crashing, for

--- a/config/crd/bases/cache.halter.io_valkeyclusters.yaml
+++ b/config/crd/bases/cache.halter.io_valkeyclusters.yaml
@@ -49,6 +49,17 @@ spec:
               image:
                 description: Valkey docker image to use
                 type: string
+              minReadySeconds:
+                description: |-
+                  An optional field that specifies the minimum number of seconds for which a
+                  newly created Pod should be ready without any of its containers crashing, for
+                  it to be considered available.
+                  This defaults to 0 (the Pod will be considered available as soon as it is ready).
+
+                  NOTE: If support for `progressDeadlineSeconds` is added in future, it must be
+                  greater than `minReadySeconds` if `minReadySeconds` is specified.
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/samples/cache_v1alpha1_valkeycluster.yaml
+++ b/config/samples/cache_v1alpha1_valkeycluster.yaml
@@ -11,6 +11,7 @@ spec:
     halter/nodegroupname: valkey
   shards: 1
   replicas: 1
+  minReadySeconds: 10
   resources:
     limits:
       cpu: "0.8"

--- a/config/samples/cache_v1alpha1_valkeycluster_kind_e2e.yaml
+++ b/config/samples/cache_v1alpha1_valkeycluster_kind_e2e.yaml
@@ -9,6 +9,7 @@ spec:
   image: valkey-server:latest
   shards: 1
   replicas: 1
+  minReadySeconds: 10
   resources:
     limits:
       cpu: "0.4"

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -1191,7 +1191,7 @@ func (r *ValkeyClusterReconciler) statefulSet(name string, size int32, valkeyClu
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls,
 			},
-			MinReadySeconds: 10,
+			MinReadySeconds: valkeyCluster.Spec.MinReadySeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: ls,

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -1191,6 +1191,7 @@ func (r *ValkeyClusterReconciler) statefulSet(name string, size int32, valkeyClu
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls,
 			},
+			MinReadySeconds: 10,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: ls,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -301,17 +301,57 @@ var _ = Describe("controller", Ordered, func() {
 			EventuallyWithOffset(1, verifyPodResources, 3*time.Minute, 15*time.Second).Should(Succeed())
 		})
 		It("change minReadySeconds", func() {
-			cmd := exec.Command("kubectl",
+			verifyClusterMinReadySeconds := func() error {
+				cmd := exec.Command("kubectl",
+					"-n", namespace,
+					"get", "valkeycluster",
+					"valkeycluster-sample", "-o", "jsonpath={.spec.minReadySeconds}",
+				)
+				minReadySeconds, err := utils.Run(cmd)
+				fmt.Println(string(minReadySeconds))
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				if string(minReadySeconds) != "10" {
+					return fmt.Errorf("expected minReadySeconds value of 10 for valkeycluster but got %s", minReadySeconds)
+				}
+				return nil
+			}
+			Eventually(verifyClusterMinReadySeconds, time.Minute, time.Second).Should(Succeed())
+
+			verifyStatefulSetMinReadySeconds := func() error {
+				cmd := exec.Command("kubectl",
+					"-n", namespace,
+					"get", "statefulset",
+					"-l", fmt.Sprintf("cache/name=%s,app.kubernetes.io/name=valkeyCluster-operator,app.kubernetes.io/managed-by=ValkeyClusterController", "valkeycluster-sample"),
+					"-o", "go-template={{ range .items }}"+
+						"{{ .spec.minReadySeconds }}"+
+						"{{ \"\\n\" }}{{ end }}",
+				)
+				statefulSetOutput, err := utils.Run(cmd)
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				statefulSetMinReadyValues := utils.GetNonEmptyLines(string(statefulSetOutput))
+				if len(statefulSetMinReadyValues) != 2 {
+					return fmt.Errorf("expected 2 statefulsets running, but got %d", len(statefulSetMinReadyValues))
+				}
+				for _, v := range statefulSetMinReadyValues {
+					if v != "10" {
+						return fmt.Errorf("expected minReadySeconds value of 10 for statefulset but got %s", v)
+					}
+				}
+				return nil
+			}
+			Eventually(verifyStatefulSetMinReadySeconds, time.Minute, time.Second).Should(Succeed())
+
+			patchCmd := exec.Command("kubectl",
 				"-n", namespace,
 				"patch", "valkeycluster", "valkeycluster-sample",
 				"--type=json",
 				`-p=[{"op":"replace","path":"/spec/minReadySeconds","value":15}]`,
 			)
-			_, err := utils.Run(cmd)
+			_, err := utils.Run(patchCmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-			verifyClusterMinReadySeconds := func() error {
-				cmd = exec.Command("kubectl",
+			reverifyClusterMinReadySeconds := func() error {
+				cmd := exec.Command("kubectl",
 					"-n", namespace,
 					"get", "valkeycluster",
 					"valkeycluster-sample", "-o", "jsonpath={.spec.minReadySeconds}",
@@ -320,11 +360,35 @@ var _ = Describe("controller", Ordered, func() {
 				fmt.Println(string(minReadySeconds))
 				ExpectWithOffset(2, err).NotTo(HaveOccurred())
 				if string(minReadySeconds) != "15" {
-					return fmt.Errorf("minReadySeconds expected to be set to 15 but got %s", minReadySeconds)
+					return fmt.Errorf("expected minReadySeconds value of 15 for valkeycluster but got %s", minReadySeconds)
 				}
 				return nil
 			}
-			Eventually(verifyClusterMinReadySeconds, time.Minute, time.Second).Should(Succeed())
+			Eventually(reverifyClusterMinReadySeconds, time.Minute, time.Second).Should(Succeed())
+
+			reverifyStatefulSetMinReadySeconds := func() error {
+				cmd := exec.Command("kubectl",
+					"-n", namespace,
+					"get", "statefulset",
+					"-l", fmt.Sprintf("cache/name=%s,app.kubernetes.io/name=valkeyCluster-operator,app.kubernetes.io/managed-by=ValkeyClusterController", "valkeycluster-sample"),
+					"-o", "go-template={{ range .items }}"+
+						"{{ .spec.minReadySeconds }}"+
+						"{{ \"\\n\" }}{{ end }}",
+				)
+				statefulSetOutput, err := utils.Run(cmd)
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				statefulSetMinReadyValues := utils.GetNonEmptyLines(string(statefulSetOutput))
+				if len(statefulSetMinReadyValues) != 2 {
+					return fmt.Errorf("expected 2 statefulsets running, but got %d", len(statefulSetMinReadyValues))
+				}
+				for _, v := range statefulSetMinReadyValues {
+					if v != "15" {
+						return fmt.Errorf("expected minReadySeconds value of 15 for statefulset but got %s", v)
+					}
+				}
+				return nil
+			}
+			Eventually(reverifyStatefulSetMinReadySeconds, time.Minute, time.Second).Should(Succeed())
 		})
 		It("change storage", func() {
 			Skip("local storage provisioner cannot resize storage")


### PR DESCRIPTION
As it says on the tin, this should pass through to pods spawned by the valkey-cluster-operator and hopefully avoid some connection timeouts from eager pod rotation when doing upgrades.

_Example of logs from operator pod_
![CleanShot 2025-06-23 at 10 46 13@2x](https://github.com/user-attachments/assets/b260eb53-6e7e-4921-ba0e-11854d1ca434)