### PR TITLE
Check if currentRevision and updateRevision are the same, if not requeue reconcile loop

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -262,6 +262,11 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 
+		// check if any update is occuring for stateful set, if so re-schedule reconcile
+		if found.Status.CurrentRevision != found.Status.UpdateRevision {
+			return ctrl.Result{RequeueAfter: time.Minute}, nil
+		}
+
 		// We can simply change the number of replicas inside the shard as that has no impact on data availabilty
 		if *found.Spec.Replicas != (statefulSetSize(valkeyCluster)) && *found.Spec.Replicas < (statefulSetSize(valkeyCluster)) {
 			log.Info(fmt.Sprintf("StatefulSet needs to increase replicas from %d to %d", *found.Spec.Replicas, (valkeyCluster.Spec.Shards + valkeyCluster.Spec.Replicas)))


### PR DESCRIPTION
This is to ensure that updates to statefulsets happen in serial rather than parallel.