### PR TITLE
Fix rolling updates and improve dagger test environment reliability

### DIFF
--- a/internal/controller/valkey/utils.go
+++ b/internal/controller/valkey/utils.go
@@ -68,11 +68,11 @@ func parseClusterNodeLine(line string) (*ClusterNode, error) {
 				parts := strings.Split(fields[i], "-")
 				start, err := strconv.Atoi(parts[0])
 				if err != nil {
-					return nil, fmt.Errorf("failed to convert string %v: line: %s", err, line)
+					return nil, fmt.Errorf("failed to convert string %w: line: %s", err, line)
 				}
 				end, err := strconv.Atoi(parts[1])
 				if err != nil {
-					return nil, fmt.Errorf("failed to convert string %v: line: %s", err, line)
+					return nil, fmt.Errorf("failed to convert string %w: line: %s", err, line)
 				}
 				slotRange := &ClusterSlotRange{
 					Start: start,
@@ -82,7 +82,7 @@ func parseClusterNodeLine(line string) (*ClusterNode, error) {
 			} else {
 				start, err := strconv.Atoi(fields[i])
 				if err != nil {
-					return nil, fmt.Errorf("failed to convert string %v: line: %s", err, line)
+					return nil, fmt.Errorf("failed to convert string %w: line: %s", err, line)
 				}
 				end := start
 				slotRange := &ClusterSlotRange{
@@ -298,7 +298,7 @@ func GenerateReshardingPlan(clusterNodesForShard map[int][]*ClusterNode, desired
 		}
 	}
 
-	for fromID, _ := range rid {
+	for fromID := range rid {
 		if rid[fromID] == 0 {
 			continue
 		}

--- a/internal/controller/valkeycluster_controller_configmap.go
+++ b/internal/controller/valkeycluster_controller_configmap.go
@@ -49,7 +49,7 @@ func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, valkeyClu
 	}
 	valkeyConfContent, err := getValkeyConfigContent(valkeyCluster)
 	if err != nil {
-		return "", fmt.Errorf("failed to read valkey config content: %v", err)
+		return "", fmt.Errorf("failed to read valkey config content: %w", err)
 	}
 	valkeyConfHash := fmt.Sprintf("%x", sha256.Sum256([]byte(valkeyConfContent)))
 	cmData["valkey.conf"] = valkeyConfContent

--- a/internal/controller/valkeycluster_controller_valkeycli.go
+++ b/internal/controller/valkeycluster_controller_valkeycli.go
@@ -36,7 +36,7 @@ func (r *ValkeyClusterReconciler) executeValkeyCli(ctx context.Context, valkeyCl
 	}, runtime.NewParameterCodec(r.Scheme))
 	exec, err := remotecommand.NewSPDYExecutor(r.RestConfig, "POST", req.URL())
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to execute valkey-cli %s: %v", strings.Join(args, " "), err)
+		return "", "", fmt.Errorf("Failed to execute valkey-cli %s: %w", strings.Join(args, " "), err)
 	}
 	var stdout, stderr bytes.Buffer
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
@@ -47,7 +47,7 @@ func (r *ValkeyClusterReconciler) executeValkeyCli(ctx context.Context, valkeyCl
 	stdoutStr := stdout.String()
 	stderrStr := stderr.String()
 	if err != nil {
-		return stdoutStr, stderrStr, fmt.Errorf("Failed executing command 'valkey-cli %s': stdout: %s, stderr: %s, err: %v", strings.Join(args, " "), stdoutStr, stderrStr, err)
+		return stdoutStr, stderrStr, fmt.Errorf("Failed executing command 'valkey-cli %s': stdout: %s, stderr: %s, err: %w", strings.Join(args, " "), stdoutStr, stderrStr, err)
 	}
 	return stdoutStr, stderrStr, nil
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -61,7 +61,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+		return output, fmt.Errorf("%s failed with error: (%w) %s", command, err, string(output))
 	}
 
 	return output, nil
@@ -87,7 +87,7 @@ func RunWithSplitOutput(cmd *exec.Cmd) ([]byte, []byte, error) {
 	stdoutBytes := stdout.Bytes()
 	stderrBytes := stderr.Bytes()
 	if err != nil {
-		return stdoutBytes, stderrBytes, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(stdoutBytes))
+		return stdoutBytes, stderrBytes, fmt.Errorf("%s failed with error: (%w) %s", command, err, string(stdoutBytes))
 	}
 
 	return stdout.Bytes(), stderr.Bytes(), nil
@@ -162,6 +162,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
Drive rolling updates one pod at a time gated on cluster health checks,
fix dagger BuildTestEnv to clean up stale Kind clusters before creating
new ones, and add proper error handling for kubeconfig retrieval.
