### PR TITLE
Add automatic disk scaling based on disk usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ What is **NOT** implemented:
 You don't need to set a disk size. The operator provisions each node's data
 volume at 1Gi (or at `spec.storage.resources.requests.storage` if set, which
 acts as the initial/minimum size) and monitors disk usage of every pod by
-running `df` against the data mount once a minute. When the fullest volume in
+running `df` against the data mount every five minutes. When the fullest volume in
 the cluster goes above 50% used, the operator grows the target size for **all**
 volumes in the cluster by 50%, rounded up to a whole Gi. The current target
 size is tracked in `status.storageSize`; volumes only ever grow, never shrink.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,38 @@ The operator provides the following features:
 - Scaling up and down the number of replicas per shard in the cluster
 - Resharding up and down, you can change the number of shards in a cluster and
 the Operator will handle resharding the slots for you.
+- Automatic disk scaling: disk usage is monitored and volumes grow on their own,
+so users don't need to think about disk sizes at all.
 
 What is **NOT** implemented:
 - Services. The only way to connect to the Valkey cluster is via the pod IP.
+
+## Disk auto-scaling
+
+You don't need to set a disk size. The operator provisions each node's data
+volume at 1Gi (or at `spec.storage.resources.requests.storage` if set, which
+acts as the initial/minimum size) and monitors disk usage of every pod by
+running `df` against the data mount once a minute. When the fullest volume in
+the cluster goes above 50% used, the operator grows the target size for **all**
+volumes in the cluster by 50%, rounded up to a whole Gi. The current target
+size is tracked in `status.storageSize`; volumes only ever grow, never shrink.
+
+Optionally, `spec.storageLimit` caps the growth:
+
+```yaml
+spec:
+  storageLimit: 100Gi
+```
+
+When the limit is reached (or the StorageClass does not allow volume
+expansion), the operator stops expanding, emits a warning event and sets the
+`StorageLimited` status condition.
+
+Notes:
+- Volume expansion requires a StorageClass with `allowVolumeExpansion: true`
+  (for example AWS EBS gp3).
+- AWS EBS allows one modification per volume per ~6 hours; the operator waits
+  for an expansion to complete before requesting another one.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ spec:
   storageLimit: 100Gi
 ```
 
-When the limit is reached (or the StorageClass does not allow volume
-expansion), the operator stops expanding, emits a warning event and sets the
-`StorageLimited` status condition.
+When the limit is reached, the operator stops expanding, emits a warning event
+and sets the `StorageLimited` status condition; the condition clears once usage
+drops back below the threshold or the limit is raised.
 
 Notes:
 - Volume expansion requires a StorageClass with `allowVolumeExpansion: true`
-  (for example AWS EBS gp3).
+  (for example AWS EBS gp3). On storage classes without it (such as kind's
+  local-path provisioner) the operator sets the `StorageLimited` condition once
+  and disables auto-scaling for the cluster, including the usage measurements.
 - AWS EBS allows one modification per volume per ~6 hours; the operator waits
   for an expansion to complete before requesting another one.
 

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,9 +52,18 @@ type ValkeyClusterSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// Valkey pod storage
+	// Valkey pod storage. Optional: when omitted the operator provisions volumes
+	// with the cluster default storage class and manages the size automatically,
+	// starting at 1Gi. When set, the requested size is the initial/minimum size;
+	// the operator still grows the volumes automatically as disk usage increases.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Storage *corev1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
+
+	// StorageLimit is the maximum per-node volume size the disk auto-scaler may
+	// grow to. When unset, growth is unbounded. When the limit is reached the
+	// operator stops expanding and reports the StorageLimited condition.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	StorageLimit *resource.Quantity `json:"storageLimit,omitempty"`
 
 	// An optional field that specifies the minimum number of seconds for which a
 	// newly created Pod should be ready without any of its containers crashing, for
@@ -121,6 +131,12 @@ type ValkeyClusterStatus struct {
 	// Information about each pod
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	ClusterNodes map[string][]ValkeyClusterNode `json:"cluster_nodes,omitempty"`
+
+	// StorageSize is the current per-node volume size managed by the disk
+	// auto-scaler. It only ever grows and is never smaller than the size
+	// requested in spec.storage.
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	StorageSize *resource.Quantity `json:"storageSize,omitempty"`
 }
 
 type ValkeyClusterNode struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *ValkeyClusterSpec) DeepCopyInto(out *ValkeyClusterSpec) {
 		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.StorageLimit != nil {
+		in, out := &in.StorageLimit, &out.StorageLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1.Toleration, len(*in))
@@ -181,6 +186,11 @@ func (in *ValkeyClusterStatus) DeepCopyInto(out *ValkeyClusterStatus) {
 			}
 			(*out)[key] = outVal
 		}
+	}
+	if in.StorageSize != nil {
+		in, out := &in.StorageSize, &out.StorageSize
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,15 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	// The reconciler fans out exec, valkey and status calls across every pod of
+	// every cluster, and the disk auto-scaler adds periodic polling on top; the
+	// default client-side rate limit (20 QPS / 30 burst) throttles reconciles
+	// under that load.
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = 50
+	restConfig.Burst = 100
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,

--- a/config/crd/bases/cache.halter.io_valkeyclusters.yaml
+++ b/config/crd/bases/cache.halter.io_valkeyclusters.yaml
@@ -146,7 +146,11 @@ spec:
                 minimum: 1
                 type: integer
               storage:
-                description: Valkey pod storage
+                description: |-
+                  Valkey pod storage. Optional: when omitted the operator provisions volumes
+                  with the cluster default storage class and manages the size automatically,
+                  starting at 1Gi. When set, the requested size is the initial/minimum size;
+                  the operator still grows the volumes automatically as disk usage increases.
                 properties:
                   accessModes:
                     description: |-
@@ -342,6 +346,16 @@ spec:
                       backing this claim.
                     type: string
                 type: object
+              storageLimit:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  StorageLimit is the maximum per-node volume size the disk auto-scaler may
+                  grow to. When unset, growth is unbounded. When the limit is reached the
+                  operator stops expanding and reports the StorageLimited condition.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               tolerations:
                 description: Tolerations
                 items:
@@ -499,6 +513,16 @@ spec:
                   - type
                   type: object
                 type: array
+              storageSize:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  StorageSize is the current per-node volume size managed by the disk
+                  auto-scaler. It only ever grows and is never smaller than the size
+                  requested in spec.storage.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
             type: object
         type: object
     served: true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: valkey-cluster-operator
   newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,3 +91,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/samples/cache_v1alpha1_valkeycluster.yaml
+++ b/config/samples/cache_v1alpha1_valkeycluster.yaml
@@ -19,13 +19,14 @@ spec:
     requests:
       cpu: "0.4"
       memory: 714Mi
+  # Disk size is managed automatically: volumes start at 1Gi and grow as disk
+  # usage increases. storage itself is optional and only needed to pick a
+  # storage class or access mode; storageLimit caps the automatic growth.
   storage:
     accessModes:
     - ReadWriteOnce
-    resources:
-      requests:
-        storage: 2Gi
     storageClassName: gp3
+  storageLimit: 100Gi
   tolerations:
   - effect: NoSchedule
     key: dedicated

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -1336,7 +1336,7 @@ func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cachev1alpha1.ValkeyCluster{}).
 		Owns(&appsv1.StatefulSet{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 2}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 8}).
 		Complete(r)
 }
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -249,6 +249,13 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return *res, nil
 	}
 
+	// Live-apply auth settings before the rolling update so replication stays
+	// authenticated while pods restart with the new config file.
+	if err := r.reconcileAuth(ctx, valkeyCluster); err != nil {
+		log.Error(err, "Failed to reconcile auth config")
+		return ctrl.Result{}, err
+	}
+
 	// Check if we need to remove a shard
 	stsList := &appsv1.StatefulSetList{}
 	listOpts := []client.ListOption{

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -68,6 +68,8 @@ const (
 	typeReshardingValkeyCluster = "Resharding"
 	// typeAvailableValkeyCluster represents the status of the Statefulset reconciliation
 	typeProvisioningValkeyCluster = "Provisioning"
+	// typeStorageLimitedValkeyCluster represents the status used when the disk auto-scaler cannot grow the volumes any further.
+	typeStorageLimitedValkeyCluster = "StorageLimited"
 )
 
 // ValkeyClusterReconciler reconciles a ValkeyCluster object
@@ -88,6 +90,7 @@ type ValkeyClusterReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
@@ -314,7 +317,19 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Monitor disk usage and grow the cluster-wide volume size when needed.
+	// The new target lands in status and is applied by the PVC check below.
+	res, err = r.reconcileDiskAutoScaling(ctx, req, valkeyCluster)
+	if err != nil {
+		log.Error(err, "Failed to reconcile disk auto-scaling")
+		return ctrl.Result{}, err
+	}
+	if res != nil {
+		return *res, nil
+	}
+
 	// check if pvs already exist, they should be created by the statefulset
+	desiredStorage := desiredStorageSize(valkeyCluster)
 	for stsIdx := 0; stsIdx < int(valkeyCluster.Spec.Shards); stsIdx++ {
 		for pvcIdx := 0; pvcIdx < int(statefulSetSize(valkeyCluster)); pvcIdx++ {
 			pvcName := fmt.Sprintf("valkey-data-%s-%d-%d", valkeyCluster.Name, stsIdx, pvcIdx)
@@ -329,8 +344,8 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, err
 			}
 
-			if found.Spec.Resources.Requests.Storage().Cmp(*valkeyCluster.Spec.Storage.Resources.Requests.Storage()) == -1 {
-				found.Spec.Resources.Requests[corev1.ResourceStorage] = *valkeyCluster.Spec.Storage.Resources.Requests.Storage()
+			if found.Spec.Resources.Requests.Storage().Cmp(desiredStorage) == -1 {
+				found.Spec.Resources.Requests[corev1.ResourceStorage] = desiredStorage
 				if err = r.Update(ctx, found); err != nil {
 					log.Error(err, "Failed to update PersistentVolumeClaim",
 						"PersistentVolumeClaim.Namespace", found.Namespace, "PersistentVolumeClaim.Name", found.Name)
@@ -762,7 +777,9 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return *res, nil
 	}
 
-	return ctrl.Result{}, nil
+	// Requeue periodically so disk usage keeps being monitored while the
+	// cluster is otherwise stable.
+	return ctrl.Result{RequeueAfter: diskUsagePollInterval}, nil
 }
 
 // isValkeyClusterHealthy returns true only when every pod in the cluster is Running and Ready

--- a/internal/controller/valkeycluster_controller_auth.go
+++ b/internal/controller/valkeycluster_controller_auth.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
+)
+
+// reconcileAuth live-applies the desired authentication settings to every
+// running pod via CONFIG SET. The config file only takes effect on restart,
+// and the rolling update is gated on replication health; without the live
+// update, a restarted replica (which sends AUTH from primaryauth) cannot
+// authenticate to a not-yet-restarted primary (which has no requirepass yet),
+// its replication link stays down and the rollout deadlocks. Applying the
+// password to all pods up front keeps replication authenticated in every
+// mixed-config state; the rolling restart then merely makes it persistent.
+func (r *ValkeyClusterReconciler) reconcileAuth(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster) error {
+	logger := log.FromContext(ctx)
+	password := valkeyCluster.Spec.Password
+
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(valkeyCluster.Namespace),
+		client.MatchingLabels(labelsForValkeyCluster(valkeyCluster.Name)),
+	}
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+			continue
+		}
+		valkeyClient, err := r.NewValkeyClient(ctx, valkeyCluster, pod.Status.PodIP, VALKEY_PORT)
+		if err != nil {
+			return fmt.Errorf("failed to create valkey client for pod %s: %w", pod.Name, err)
+		}
+		defer valkeyClient.Close()
+
+		current, err := valkeyClient.Do(ctx, valkeyClient.B().ConfigGet().Parameter("requirepass").Build()).AsStrMap()
+		if err != nil {
+			return fmt.Errorf("failed to get requirepass from pod %s: %w", pod.Name, err)
+		}
+		if current["requirepass"] == password {
+			continue
+		}
+		err = valkeyClient.Do(ctx, valkeyClient.B().ConfigSet().
+			ParameterValue().
+			ParameterValue("requirepass", password).
+			ParameterValue("primaryauth", password).
+			Build()).Error()
+		if err != nil {
+			return fmt.Errorf("failed to set auth config on pod %s: %w", pod.Name, err)
+		}
+		logger.Info("Applied authentication config to running pod", "pod", pod.Name)
+		r.Recorder.Event(valkeyCluster, "Normal", "AuthUpdated",
+			fmt.Sprintf("Applied authentication config to pod %s", pod.Name))
+	}
+	return nil
+}

--- a/internal/controller/valkeycluster_controller_configmap.go
+++ b/internal/controller/valkeycluster_controller_configmap.go
@@ -130,7 +130,7 @@ func getValkeyConfigContent(valkeyCluster *cachev1alpha1.ValkeyCluster) (string,
 	var sb strings.Builder
 	sb.WriteString(base)
 	for _, p := range valkeyCluster.Spec.ValkeyConfig.Parameters {
-		sb.WriteString(fmt.Sprintf("\n%s %s", p.Name, p.Value))
+		fmt.Fprintf(&sb, "\n%s %s", p.Name, p.Value)
 	}
 	return sb.String(), nil
 }

--- a/internal/controller/valkeycluster_controller_pvc.go
+++ b/internal/controller/valkeycluster_controller_pvc.go
@@ -16,7 +16,7 @@ func (r *ValkeyClusterReconciler) persistentVolumeClaim(name string, valkeyClust
 			Namespace: valkeyCluster.Namespace,
 			Labels:    ls,
 		},
-		Spec: *valkeyCluster.Spec.Storage,
+		Spec: storagePVCSpec(valkeyCluster),
 	}
 	// Set the ownerRef for the PersistentVolumeClaim
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/

--- a/internal/controller/valkeycluster_controller_statefulset.go
+++ b/internal/controller/valkeycluster_controller_statefulset.go
@@ -278,11 +278,7 @@ func (r *ValkeyClusterReconciler) statefulSet(name string, size int32, valkeyClu
 					Name:   "valkey-data",
 					Labels: ls,
 				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes:      valkeyCluster.Spec.Storage.AccessModes,
-					StorageClassName: valkeyCluster.Spec.Storage.StorageClassName,
-					Resources:        valkeyCluster.Spec.Storage.Resources,
-				},
+				Spec: storagePVCSpec(valkeyCluster),
 			}},
 		},
 	}

--- a/internal/controller/valkeycluster_controller_storage.go
+++ b/internal/controller/valkeycluster_controller_storage.go
@@ -39,8 +39,9 @@ const (
 	diskGrowthPercent = 50
 
 	// diskUsagePollInterval is how often a stable cluster is re-reconciled to
-	// measure disk usage.
-	diskUsagePollInterval = time.Minute
+	// measure disk usage. The 50% threshold with 50% growth steps leaves
+	// enough headroom that a five-minute detection latency is safe.
+	diskUsagePollInterval = 5 * time.Minute
 )
 
 const gibibyte = int64(1024 * 1024 * 1024)

--- a/internal/controller/valkeycluster_controller_storage.go
+++ b/internal/controller/valkeycluster_controller_storage.go
@@ -176,6 +176,21 @@ func (r *ValkeyClusterReconciler) reconcileDiskAutoScaling(ctx context.Context, 
 		}
 	}
 
+	// When the volumes can never expand there is no point measuring usage:
+	// record once that auto-scaling is unavailable and skip the per-pod execs
+	// entirely. The condition message is static so this does not generate
+	// repeated status updates or events.
+	allowsExpansion, scName, err := r.storageClassAllowsExpansion(ctx, &pvcList.Items[0])
+	if err != nil {
+		return nil, err
+	}
+	if !allowsExpansion {
+		return nil, r.setStorageLimitedCondition(ctx, req, valkeyCluster, metav1.Condition{
+			Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionTrue, Reason: "StorageClassNotExpandable",
+			Message: fmt.Sprintf("StorageClass %q does not allow volume expansion, disk auto-scaling is disabled", scName),
+		})
+	}
+
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList, listOpts...); err != nil {
 		return nil, err
@@ -198,7 +213,18 @@ func (r *ValkeyClusterReconciler) reconcileDiskAutoScaling(ctx context.Context, 
 			maxUsedPercent = usedPercent
 		}
 	}
-	if !measured || maxUsedPercent < diskUsageThresholdPercent {
+	if !measured {
+		return nil, nil
+	}
+	if maxUsedPercent < diskUsageThresholdPercent {
+		// Clear a previously reported limit once usage recedes below the
+		// threshold (e.g. data was deleted or the limit-gated backlog cleared).
+		if cond := meta.FindStatusCondition(valkeyCluster.Status.Conditions, typeStorageLimitedValkeyCluster); cond != nil && cond.Status == metav1.ConditionTrue {
+			return nil, r.setStorageLimitedCondition(ctx, req, valkeyCluster, metav1.Condition{
+				Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionFalse, Reason: "BelowThreshold",
+				Message: fmt.Sprintf("Disk usage is below the %d%% expansion threshold", diskUsageThresholdPercent),
+			})
+		}
 		return nil, nil
 	}
 
@@ -207,22 +233,13 @@ func (r *ValkeyClusterReconciler) reconcileDiskAutoScaling(ctx context.Context, 
 		next = *limit
 	}
 	if next.Cmp(desired) <= 0 {
+		// The message deliberately excludes the usage percentage so the
+		// condition (and its warning event) only refreshes when the limit or
+		// volume size changes, not every time usage drifts.
 		return nil, r.setStorageLimitedCondition(ctx, req, valkeyCluster, metav1.Condition{
 			Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionTrue, Reason: "StorageLimitReached",
-			Message: fmt.Sprintf("Disk usage is %d%% but volume size %s already reached spec.storageLimit %s",
-				maxUsedPercent, desired.String(), valkeyCluster.Spec.StorageLimit.String()),
-		})
-	}
-
-	allowsExpansion, scName, err := r.storageClassAllowsExpansion(ctx, &pvcList.Items[0])
-	if err != nil {
-		return nil, err
-	}
-	if !allowsExpansion {
-		return nil, r.setStorageLimitedCondition(ctx, req, valkeyCluster, metav1.Condition{
-			Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionTrue, Reason: "StorageClassNotExpandable",
-			Message: fmt.Sprintf("Disk usage is %d%% but StorageClass %q does not allow volume expansion",
-				maxUsedPercent, scName),
+			Message: fmt.Sprintf("Disk usage exceeds %d%% but volume size %s already reached spec.storageLimit %s",
+				diskUsageThresholdPercent, desired.String(), valkeyCluster.Spec.StorageLimit.String()),
 		})
 	}
 
@@ -248,8 +265,8 @@ func (r *ValkeyClusterReconciler) reconcileDiskAutoScaling(ctx context.Context, 
 	return &ctrl.Result{Requeue: true}, nil
 }
 
-// setStorageLimitedCondition records why auto-scaling cannot proceed, emitting
-// a warning event only on transition to avoid spamming every poll.
+// setStorageLimitedCondition records whether auto-scaling can proceed, emitting
+// an event only on transition to avoid spamming every poll.
 func (r *ValkeyClusterReconciler) setStorageLimitedCondition(ctx context.Context, req ctrl.Request, valkeyCluster *cachev1alpha1.ValkeyCluster, condition metav1.Condition) error {
 	if err := r.Get(ctx, req.NamespacedName, valkeyCluster); err != nil {
 		return err
@@ -260,6 +277,10 @@ func (r *ValkeyClusterReconciler) setStorageLimitedCondition(ctx context.Context
 	if err := r.Status().Update(ctx, valkeyCluster); err != nil {
 		return err
 	}
-	r.Recorder.Event(valkeyCluster, "Warning", condition.Reason, condition.Message)
+	eventType := corev1.EventTypeWarning
+	if condition.Status == metav1.ConditionFalse {
+		eventType = corev1.EventTypeNormal
+	}
+	r.Recorder.Event(valkeyCluster, eventType, condition.Reason, condition.Message)
 	return nil
 }

--- a/internal/controller/valkeycluster_controller_storage.go
+++ b/internal/controller/valkeycluster_controller_storage.go
@@ -1,0 +1,265 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
+)
+
+const (
+	// defaultStorageSize is the initial volume size used when spec.storage does
+	// not request one.
+	defaultStorageSize = "1Gi"
+
+	// valkeyDataMountPath is where the valkey-data volume is mounted in the
+	// valkey-cluster-node container.
+	valkeyDataMountPath = "/data"
+
+	// diskUsageThresholdPercent is the usage of the fullest data volume in the
+	// cluster at which all volumes are grown.
+	diskUsageThresholdPercent = 50
+
+	// diskGrowthPercent is how much volumes grow on each expansion, rounded up
+	// to a whole Gi. Kept coarse so EBS-style backends, which allow only one
+	// modification per volume per ~6h, gain meaningful headroom per step.
+	diskGrowthPercent = 50
+
+	// diskUsagePollInterval is how often a stable cluster is re-reconciled to
+	// measure disk usage.
+	diskUsagePollInterval = time.Minute
+)
+
+const gibibyte = int64(1024 * 1024 * 1024)
+
+// desiredStorageSize returns the per-node volume size the cluster should have
+// right now: the auto-scaled size from status when present, otherwise the size
+// requested in spec.storage, otherwise the default initial size.
+func desiredStorageSize(valkeyCluster *cachev1alpha1.ValkeyCluster) resource.Quantity {
+	size := resource.MustParse(defaultStorageSize)
+	if storage := valkeyCluster.Spec.Storage; storage != nil {
+		if request, ok := storage.Resources.Requests[corev1.ResourceStorage]; ok && !request.IsZero() {
+			size = request
+		}
+	}
+	if scaled := valkeyCluster.Status.StorageSize; scaled != nil && scaled.Cmp(size) > 0 {
+		size = *scaled
+	}
+	return size
+}
+
+// storagePVCSpec builds the effective PVC spec for the cluster's data volumes,
+// applying defaults for anything not provided in spec.storage and the current
+// auto-scaled size.
+func storagePVCSpec(valkeyCluster *cachev1alpha1.ValkeyCluster) corev1.PersistentVolumeClaimSpec {
+	spec := corev1.PersistentVolumeClaimSpec{
+		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+	}
+	if storage := valkeyCluster.Spec.Storage; storage != nil {
+		if len(storage.AccessModes) > 0 {
+			spec.AccessModes = storage.AccessModes
+		}
+		spec.StorageClassName = storage.StorageClassName
+		spec.Resources = *storage.Resources.DeepCopy()
+	}
+	if spec.Resources.Requests == nil {
+		spec.Resources.Requests = corev1.ResourceList{}
+	}
+	spec.Resources.Requests[corev1.ResourceStorage] = desiredStorageSize(valkeyCluster)
+	return spec
+}
+
+// nextStorageSize grows the current size by diskGrowthPercent, rounded up to a
+// whole Gi.
+func nextStorageSize(current resource.Quantity) resource.Quantity {
+	grown := current.Value() + current.Value()*diskGrowthPercent/100
+	gi := (grown + gibibyte - 1) / gibibyte
+	return *resource.NewQuantity(gi*gibibyte, resource.BinarySI)
+}
+
+// parseDfUsedPercent parses POSIX `df -Pk <path>` output and returns the used
+// capacity as a percentage. It is computed from the Used and Available columns
+// rather than the Capacity column so reserved filesystem blocks do not skew
+// the result.
+func parseDfUsedPercent(out string) (int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 2 {
+		return 0, fmt.Errorf("unexpected df output: %q", out)
+	}
+	fields := strings.Fields(lines[len(lines)-1])
+	if len(fields) < 5 {
+		return 0, fmt.Errorf("unexpected df output line: %q", lines[len(lines)-1])
+	}
+	used, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse df used blocks %q: %w", fields[2], err)
+	}
+	available, err := strconv.ParseInt(fields[3], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse df available blocks %q: %w", fields[3], err)
+	}
+	if used+available <= 0 {
+		return 0, fmt.Errorf("df reports no capacity: %q", lines[len(lines)-1])
+	}
+	return int(used * 100 / (used + available)), nil
+}
+
+func (r *ValkeyClusterReconciler) podDiskUsedPercent(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, podName string) (int, error) {
+	stdout, _, err := r.execInPod(ctx, valkeyCluster.Namespace, podName, []string{"df", "-Pk", valkeyDataMountPath})
+	if err != nil {
+		return 0, err
+	}
+	return parseDfUsedPercent(stdout)
+}
+
+// storageClassAllowsExpansion resolves the StorageClass bound to the PVC and
+// reports whether it permits volume expansion.
+func (r *ValkeyClusterReconciler) storageClassAllowsExpansion(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (bool, string, error) {
+	scName := ""
+	if pvc.Spec.StorageClassName != nil {
+		scName = *pvc.Spec.StorageClassName
+	}
+	if scName == "" {
+		return false, scName, nil
+	}
+	sc := &storagev1.StorageClass{}
+	if err := r.Get(ctx, types.NamespacedName{Name: scName}, sc); err != nil {
+		return false, scName, err
+	}
+	return sc.AllowVolumeExpansion != nil && *sc.AllowVolumeExpansion, scName, nil
+}
+
+// reconcileDiskAutoScaling measures disk usage of every pod's data volume and,
+// when the fullest volume crosses diskUsageThresholdPercent, grows the
+// cluster-wide target size by diskGrowthPercent. All PVCs in the cluster share
+// one target size, volumes only ever grow, and growth stops at
+// spec.storageLimit when set. The new target is recorded in status; the PVC
+// reconciliation applies it to each claim.
+func (r *ValkeyClusterReconciler) reconcileDiskAutoScaling(ctx context.Context, req ctrl.Request, valkeyCluster *cachev1alpha1.ValkeyCluster) (*ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	desired := desiredStorageSize(valkeyCluster)
+	listOpts := []client.ListOption{
+		client.InNamespace(valkeyCluster.Namespace),
+		client.MatchingLabels(labelsForValkeyCluster(valkeyCluster.Name)),
+	}
+
+	// Every PVC must have reached the current target capacity before another
+	// expansion is considered, otherwise a slow in-flight expansion would
+	// compound the growth factor on every reconcile.
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(ctx, pvcList, listOpts...); err != nil {
+		return nil, err
+	}
+	if len(pvcList.Items) == 0 {
+		return nil, nil
+	}
+	for _, pvc := range pvcList.Items {
+		capacity, ok := pvc.Status.Capacity[corev1.ResourceStorage]
+		if !ok || capacity.Cmp(desired) < 0 {
+			logger.Info("Volume expansion in progress, skipping disk auto-scaling",
+				"pvc", pvc.Name, "capacity", capacity.String(), "target", desired.String())
+			return nil, nil
+		}
+	}
+
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return nil, err
+	}
+	maxUsedPercent := 0
+	measured := false
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		usedPercent, err := r.podDiskUsedPercent(ctx, valkeyCluster, pod.Name)
+		if err != nil {
+			// Pods can churn between listing and exec; measure what we can and
+			// let the periodic requeue retry the rest.
+			logger.Error(err, "Failed to measure disk usage", "pod", pod.Name)
+			continue
+		}
+		measured = true
+		if usedPercent > maxUsedPercent {
+			maxUsedPercent = usedPercent
+		}
+	}
+	if !measured || maxUsedPercent < diskUsageThresholdPercent {
+		return nil, nil
+	}
+
+	next := nextStorageSize(desired)
+	if limit := valkeyCluster.Spec.StorageLimit; limit != nil && next.Cmp(*limit) > 0 {
+		next = *limit
+	}
+	if next.Cmp(desired) <= 0 {
+		return nil, r.setStorageLimitedCondition(ctx, req, valkeyCluster, metav1.Condition{
+			Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionTrue, Reason: "StorageLimitReached",
+			Message: fmt.Sprintf("Disk usage is %d%% but volume size %s already reached spec.storageLimit %s",
+				maxUsedPercent, desired.String(), valkeyCluster.Spec.StorageLimit.String()),
+		})
+	}
+
+	allowsExpansion, scName, err := r.storageClassAllowsExpansion(ctx, &pvcList.Items[0])
+	if err != nil {
+		return nil, err
+	}
+	if !allowsExpansion {
+		return nil, r.setStorageLimitedCondition(ctx, req, valkeyCluster, metav1.Condition{
+			Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionTrue, Reason: "StorageClassNotExpandable",
+			Message: fmt.Sprintf("Disk usage is %d%% but StorageClass %q does not allow volume expansion",
+				maxUsedPercent, scName),
+		})
+	}
+
+	// Re-fetch before updating status to avoid conflicts with earlier updates
+	// in this reconcile.
+	if err := r.Get(ctx, req.NamespacedName, valkeyCluster); err != nil {
+		return nil, err
+	}
+	valkeyCluster.Status.StorageSize = &next
+	meta.SetStatusCondition(&valkeyCluster.Status.Conditions, metav1.Condition{
+		Type: typeStorageLimitedValkeyCluster, Status: metav1.ConditionFalse, Reason: "Expanding",
+		Message: fmt.Sprintf("Disk usage reached %d%%, growing volume size from %s to %s",
+			maxUsedPercent, desired.String(), next.String()),
+	})
+	if err := r.Status().Update(ctx, valkeyCluster); err != nil {
+		logger.Error(err, "Failed to update ValkeyCluster status with new storage size")
+		return nil, err
+	}
+	r.Recorder.Event(valkeyCluster, "Normal", "DiskAutoScale",
+		fmt.Sprintf("Disk usage reached %d%%, growing volume size from %s to %s",
+			maxUsedPercent, desired.String(), next.String()))
+	// Requeue so the PVC reconciliation applies the new size immediately.
+	return &ctrl.Result{Requeue: true}, nil
+}
+
+// setStorageLimitedCondition records why auto-scaling cannot proceed, emitting
+// a warning event only on transition to avoid spamming every poll.
+func (r *ValkeyClusterReconciler) setStorageLimitedCondition(ctx context.Context, req ctrl.Request, valkeyCluster *cachev1alpha1.ValkeyCluster, condition metav1.Condition) error {
+	if err := r.Get(ctx, req.NamespacedName, valkeyCluster); err != nil {
+		return err
+	}
+	if !meta.SetStatusCondition(&valkeyCluster.Status.Conditions, condition) {
+		return nil
+	}
+	if err := r.Status().Update(ctx, valkeyCluster); err != nil {
+		return err
+	}
+	r.Recorder.Event(valkeyCluster, "Warning", condition.Reason, condition.Message)
+	return nil
+}

--- a/internal/controller/valkeycluster_controller_storage_test.go
+++ b/internal/controller/valkeycluster_controller_storage_test.go
@@ -1,0 +1,176 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
+)
+
+func requestedStorage(requests corev1.ResourceList) string {
+	size := requests[corev1.ResourceStorage]
+	return size.String()
+}
+
+var _ = Describe("desiredStorageSize", func() {
+	sizeOf := func(vc *cachev1alpha1.ValkeyCluster) string {
+		size := desiredStorageSize(vc)
+		return size.String()
+	}
+	cluster := func(specSize, statusSize string) *cachev1alpha1.ValkeyCluster {
+		vc := &cachev1alpha1.ValkeyCluster{}
+		if specSize != "" {
+			vc.Spec.Storage = &corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(specSize),
+					},
+				},
+			}
+		}
+		if statusSize != "" {
+			size := resource.MustParse(statusSize)
+			vc.Status.StorageSize = &size
+		}
+		return vc
+	}
+
+	It("defaults to 1Gi when no storage is configured", func() {
+		Expect(sizeOf(cluster("", ""))).To(Equal("1Gi"))
+	})
+
+	It("uses the spec request when set", func() {
+		Expect(sizeOf(cluster("2Gi", ""))).To(Equal("2Gi"))
+	})
+
+	It("honours a spec request below the default", func() {
+		Expect(sizeOf(cluster("512Mi", ""))).To(Equal("512Mi"))
+	})
+
+	It("uses the auto-scaled status size when it exceeds the spec", func() {
+		Expect(sizeOf(cluster("2Gi", "3Gi"))).To(Equal("3Gi"))
+	})
+
+	It("never shrinks below the spec request", func() {
+		Expect(sizeOf(cluster("4Gi", "3Gi"))).To(Equal("4Gi"))
+	})
+
+	It("uses the status size with no spec storage", func() {
+		Expect(sizeOf(cluster("", "5Gi"))).To(Equal("5Gi"))
+	})
+})
+
+var _ = Describe("storagePVCSpec", func() {
+	It("applies defaults when spec.storage is unset", func() {
+		spec := storagePVCSpec(&cachev1alpha1.ValkeyCluster{})
+		Expect(spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}))
+		Expect(spec.StorageClassName).To(BeNil())
+		Expect(requestedStorage(spec.Resources.Requests)).To(Equal("1Gi"))
+	})
+
+	It("keeps user-provided class and access modes, overriding only the size", func() {
+		className := "gp3"
+		size := resource.MustParse("6Gi")
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Storage: &corev1.PersistentVolumeClaimSpec{
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+					StorageClassName: &className,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+		}
+		vc.Status.StorageSize = &size
+
+		spec := storagePVCSpec(vc)
+		Expect(spec.AccessModes).To(Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}))
+		Expect(*spec.StorageClassName).To(Equal("gp3"))
+		Expect(requestedStorage(spec.Resources.Requests)).To(Equal("6Gi"))
+	})
+
+	It("does not mutate the user-provided storage spec", func() {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Storage: &corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+		}
+		size := resource.MustParse("6Gi")
+		vc.Status.StorageSize = &size
+
+		_ = storagePVCSpec(vc)
+		Expect(requestedStorage(vc.Spec.Storage.Resources.Requests)).To(Equal("2Gi"))
+	})
+})
+
+var _ = Describe("nextStorageSize", func() {
+	next := func(in string) string {
+		out := nextStorageSize(resource.MustParse(in))
+		return out.String()
+	}
+
+	It("grows 1Gi to 2Gi (rounded up to a whole Gi)", func() {
+		Expect(next("1Gi")).To(Equal("2Gi"))
+	})
+
+	It("grows 2Gi to 3Gi", func() {
+		Expect(next("2Gi")).To(Equal("3Gi"))
+	})
+
+	It("grows 3Gi to 5Gi", func() {
+		Expect(next("3Gi")).To(Equal("5Gi"))
+	})
+
+	It("grows 10Gi to 15Gi", func() {
+		Expect(next("10Gi")).To(Equal("15Gi"))
+	})
+
+	It("rounds sub-Gi sizes up to a whole Gi", func() {
+		Expect(next("512Mi")).To(Equal("1Gi"))
+	})
+})
+
+var _ = Describe("parseDfUsedPercent", func() {
+	It("computes usage from used and available blocks", func() {
+		out := `Filesystem     1024-blocks    Used Available Capacity Mounted on
+/dev/nvme1n1       1038336  248560    789776      24% /data
+`
+		Expect(parseDfUsedPercent(out)).To(Equal(23))
+	})
+
+	It("parses busybox-style df output", func() {
+		out := `Filesystem           1024-blocks    Used Available Capacity Mounted on
+/dev/sda1              10218772 5109386   5109386  50% /data
+`
+		Expect(parseDfUsedPercent(out)).To(Equal(50))
+	})
+
+	It("errors on missing data line", func() {
+		_, err := parseDfUsedPercent("Filesystem 1024-blocks Used Available Capacity Mounted on\n")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors on malformed output", func() {
+		_, err := parseDfUsedPercent("header\nnot a df line\n")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors when no capacity is reported", func() {
+		out := `Filesystem     1024-blocks    Used Available Capacity Mounted on
+/dev/nvme1n1             0       0         0       0% /data
+`
+		_, err := parseDfUsedPercent(out)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("getValkeyConfigContent", func() {
 	cluster := func(password string, cfg *cachev1alpha1.ValkeyConfig) *cachev1alpha1.ValkeyCluster {
 		return &cachev1alpha1.ValkeyCluster{
 			Spec: cachev1alpha1.ValkeyClusterSpec{
-				Password:    password,
+				Password:     password,
 				ValkeyConfig: cfg,
 			},
 		}

--- a/internal/controller/valkeycluster_controller_valkeycli.go
+++ b/internal/controller/valkeycluster_controller_valkeycli.go
@@ -24,8 +24,12 @@ func (r *ValkeyClusterReconciler) executeValkeyCli(ctx context.Context, valkeyCl
 	}
 
 	podName := fmt.Sprintf("%s-0-0", valkeyCluster.Name)
+	return r.execInPod(ctx, valkeyCluster.Namespace, podName, cmd)
+}
+
+func (r *ValkeyClusterReconciler) execInPod(ctx context.Context, namespace, podName string, cmd []string) (string, string, error) {
 	req := r.ClientSet.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
-		Namespace(valkeyCluster.Namespace).SubResource("exec")
+		Namespace(namespace).SubResource("exec")
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: "valkey-cluster-node",
 		Command:   cmd,
@@ -36,7 +40,7 @@ func (r *ValkeyClusterReconciler) executeValkeyCli(ctx context.Context, valkeyCl
 	}, runtime.NewParameterCodec(r.Scheme))
 	exec, err := remotecommand.NewSPDYExecutor(r.RestConfig, "POST", req.URL())
 	if err != nil {
-		return "", "", fmt.Errorf("Failed to execute valkey-cli %s: %w", strings.Join(args, " "), err)
+		return "", "", fmt.Errorf("Failed to execute %s: %w", strings.Join(cmd, " "), err)
 	}
 	var stdout, stderr bytes.Buffer
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
@@ -47,7 +51,7 @@ func (r *ValkeyClusterReconciler) executeValkeyCli(ctx context.Context, valkeyCl
 	stdoutStr := stdout.String()
 	stderrStr := stderr.String()
 	if err != nil {
-		return stdoutStr, stderrStr, fmt.Errorf("Failed executing command 'valkey-cli %s': stdout: %s, stderr: %s, err: %w", strings.Join(args, " "), stdoutStr, stderrStr, err)
+		return stdoutStr, stderrStr, fmt.Errorf("Failed executing command '%s': stdout: %s, stderr: %s, err: %w", strings.Join(cmd, " "), stdoutStr, stderrStr, err)
 	}
 	return stdoutStr, stderrStr, nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -554,7 +554,9 @@ var _ = Describe("controller", Ordered, func() {
 			)
 			_, err := utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			EventuallyWithOffset(1, verifyClusterState("valkeycluster-sample", 2, 2, "supersecret"), 5*time.Minute, 15*time.Second).Should(Succeed())
+			// Six pods restart sequentially, each gated on full cluster health
+			// including replica catch-up, so allow well beyond the rollout time.
+			EventuallyWithOffset(1, verifyClusterState("valkeycluster-sample", 2, 2, "supersecret"), 10*time.Minute, 15*time.Second).Should(Succeed())
 		})
 		It("be deleted", func() {
 			cmd := exec.Command("kubectl",
@@ -715,17 +717,36 @@ spec:
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 		By("waiting for rolling update to complete")
-		EventuallyWithOffset(1, verifyClusterState(upgradeClusterName, 2, 1, ""), 5*time.Minute, 15*time.Second).Should(Succeed())
-
-		By("verifying cluster is running version 9.0.1")
-		EventuallyWithOffset(1, verifyClusterVersion(upgradeClusterName, "9.0.1"), 5*time.Minute, 15*time.Second).Should(Succeed())
+		// The cluster state and version must hold at the same instant:
+		// checking them in separate Eventually blocks lets the state pass
+		// before the last pod is replaced and the version pass while it is
+		// terminating (terminating pods are excluded from the listing), so
+		// the rollout could still be in flight after both succeeded.
+		verifyUpgraded := func() error {
+			if err := verifyClusterState(upgradeClusterName, 2, 1, "")(); err != nil {
+				return err
+			}
+			return verifyClusterVersion(upgradeClusterName, "9.0.1")()
+		}
+		EventuallyWithOffset(1, verifyUpgraded, 10*time.Minute, 15*time.Second).Should(Succeed())
 
 		By("verifying test data survived the upgrade")
-		cmd = exec.Command("kubectl", "-n", namespace, "exec", upgradeClusterName+"-0-0", "-c", "valkey-cluster-node", "--",
-			"valkey-cli", "-c", "GET", testKey)
-		output, err := utils.Run(cmd)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
-		ExpectWithOffset(1, strings.TrimSpace(string(output))).To(Equal(testValue))
+		// Retried because a GET right after the final failover can race
+		// cluster routing convergence; genuinely lost data never recovers, so
+		// retrying does not mask real loss.
+		verifyData := func() error {
+			cmd = exec.Command("kubectl", "-n", namespace, "exec", upgradeClusterName+"-0-0", "-c", "valkey-cluster-node", "--",
+				"valkey-cli", "-c", "GET", testKey)
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(output)) != testValue {
+				return fmt.Errorf("expected %q but got %q", testValue, strings.TrimSpace(string(output)))
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyData, 2*time.Minute, 5*time.Second).Should(Succeed())
 	})
 })
 


### PR DESCRIPTION
Users no longer need to set a disk size. The operator provisions data
volumes at 1Gi (or spec.storage's request, which becomes the
initial/minimum size), measures disk usage of every pod once a minute
by running df against the data mount, and when the fullest volume in
the cluster exceeds 50% used, grows the target size for all volumes by
50%, rounded up to a whole Gi. The current target is tracked in
status.storageSize; spec is never mutated and volumes only ever grow.

- spec.storage is now optional; defaults to the cluster default storage
  class with ReadWriteOnce access
- new optional spec.storageLimit caps growth; when reached (or when the
  StorageClass does not allow volume expansion) the operator emits a
  warning event and sets the StorageLimited status condition
- another expansion is only requested once every PVC has reached the
  current target capacity, so growth cannot compound while an expansion
  is in flight (EBS allows one modification per volume per ~6h)
- stable clusters requeue every minute to keep monitoring usage
