### PR TITLE
Keep valkey-cli Job names within the 63-character label limit

### DIFF
--- a/internal/controller/valkeycluster_controller_valkeycli_job.go
+++ b/internal/controller/valkeycluster_controller_valkeycli_job.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"strings"
@@ -26,7 +27,7 @@ func (r *ValkeyClusterReconciler) executeValkeyCliJob(ctx context.Context, valke
 	logger := log.FromContext(ctx)
 
 	// Generate unique job name based on timestamp and operation
-	jobName := fmt.Sprintf("%s-valkey-cli-%d", valkeyCluster.Name, time.Now().Unix())
+	jobName := valkeyCliJobName(valkeyCluster.Name, time.Now().Unix())
 
 	// Create the Job
 	job := r.buildValkeyCliJob(jobName, valkeyCluster, args)
@@ -50,6 +51,25 @@ func (r *ValkeyClusterReconciler) executeValkeyCliJob(ctx context.Context, valke
 	}
 
 	return stdout, stderr, err
+}
+
+// maxJobNameLength caps Job names at 63 characters: Kubernetes copies the Job
+// name into the job-name label on the Job's pods, and label values are limited
+// to 63 characters.
+const maxJobNameLength = 63
+
+// valkeyCliJobName returns "<cluster>-valkey-cli-<timestamp>", truncating long
+// cluster names and appending a short hash of the full name so that names stay
+// unique across clusters that share a truncated prefix.
+func valkeyCliJobName(clusterName string, timestamp int64) string {
+	suffix := fmt.Sprintf("-valkey-cli-%d", timestamp)
+	maxPrefix := maxJobNameLength - len(suffix)
+	if len(clusterName) <= maxPrefix {
+		return clusterName + suffix
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(clusterName)))[:8]
+	prefix := strings.TrimRight(clusterName[:maxPrefix-len(hash)-1], "-")
+	return fmt.Sprintf("%s-%s%s", prefix, hash, suffix)
 }
 
 // buildValkeyCliJob creates a Job spec for running valkey-cli commands

--- a/internal/controller/valkeycluster_controller_valkeycli_job_test.go
+++ b/internal/controller/valkeycluster_controller_valkeycli_job_test.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+var _ = Describe("valkeyCliJobName", func() {
+	const timestamp = int64(1789000000)
+
+	It("uses the cluster name unchanged when the result fits", func() {
+		Expect(valkeyCliJobName("my-cluster", timestamp)).
+			To(Equal("my-cluster-valkey-cli-1789000000"))
+	})
+
+	It("stays within 63 characters for long cluster names", func() {
+		longName := strings.Repeat("a", 45) + "-cluster"
+		name := valkeyCliJobName(longName, timestamp)
+		Expect(len(name)).To(BeNumerically("<=", maxJobNameLength))
+		Expect(validation.IsDNS1123Label(name)).To(BeEmpty())
+		Expect(name).To(HavePrefix("aaaa"))
+		Expect(name).To(HaveSuffix("-valkey-cli-1789000000"))
+	})
+
+	It("produces distinct names for long cluster names sharing a prefix", func() {
+		sharedPrefix := strings.Repeat("a", 60)
+		nameOne := valkeyCliJobName(sharedPrefix+"-one", timestamp)
+		nameTwo := valkeyCliJobName(sharedPrefix+"-two", timestamp)
+		Expect(nameOne).NotTo(Equal(nameTwo))
+	})
+
+	It("remains a valid DNS-1123 label when truncation lands on a dash", func() {
+		// Choose a name whose truncation point falls right after a dash so the
+		// untrimmed prefix would end in one.
+		longName := strings.Repeat("a", 31) + "-" + strings.Repeat("b", 20)
+		name := valkeyCliJobName(longName, timestamp)
+		Expect(len(name)).To(BeNumerically("<=", maxJobNameLength))
+		Expect(validation.IsDNS1123Label(name)).To(BeEmpty())
+		Expect(name).NotTo(ContainSubstring("--"))
+	})
+})


### PR DESCRIPTION
## Problem

valkey-cli Job names are built as `<cluster>-valkey-cli-<unix-timestamp>`. For a sufficiently long `ValkeyCluster` name (≥42 characters), the resulting Job name exceeds 63 characters. Kubernetes copies the Job name into the auto-derived `job-name` label on the Job's pod template, and label values are limited to 63 characters, so Job creation fails admission validation. This blocks every valkey-cli Job operation — reshard, cluster check, and cluster fix — for clusters with long names.

## Fix

Add a `valkeyCliJobName` helper that keeps the full cluster name when it fits, and otherwise truncates it and appends a short SHA-256 hash of the full name so clusters sharing a truncated prefix still get distinct Job names. The result is always ≤63 characters and a valid DNS-1123 label.

## Testing

- New unit tests cover: short names unchanged, long names capped at 63 chars and DNS-1123 valid, distinct names for long clusters sharing a prefix, and truncation landing on a dash.
- `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)