### PR TITLE
Fix resharding plan generating zero-slot and misdirected migrations

### DIFF
--- a/internal/controller/valkey/utils.go
+++ b/internal/controller/valkey/utils.go
@@ -237,32 +237,30 @@ func GenerateReshardingPlan(clusterNodesForShard map[int][]*ClusterNode, desired
 		}
 	}
 
-	desiredSlotCounts := SlotCounts(int(desiredShards))
-	actualSlotCounts := []int{}
+	desiredSlotCounts := SlotCounts(desiredShards)
 	maxIdx := 0
 	for idx := range clusterNodesForShard {
 		if idx > maxIdx {
 			maxIdx = idx
 		}
 	}
+	// One entry per shard index so counts stay aligned with primaries,
+	// including shards whose primary currently holds no slots.
+	actualSlotCounts := make([]int, 0, maxIdx+1)
 	for i := 0; i <= maxIdx; i++ {
-		for _, cn := range clusterNodesForShard[i] {
-			if cn.IsMaster() && cn.HasSlots() {
-				actualSlotCounts = append(actualSlotCounts, cn.SlotCount())
-			}
+		if primary, ok := primaries[i]; ok {
+			actualSlotCounts = append(actualSlotCounts, primary.SlotCount())
+		} else {
+			actualSlotCounts = append(actualSlotCounts, 0)
 		}
 	}
 
 	// pad with 0s
-	if len(desiredSlotCounts) < len(actualSlotCounts) {
-		for i := 0; i < len(actualSlotCounts)-len(desiredSlotCounts); i++ {
-			desiredSlotCounts = append(desiredSlotCounts, 0)
-		}
+	for len(desiredSlotCounts) < len(actualSlotCounts) {
+		desiredSlotCounts = append(desiredSlotCounts, 0)
 	}
-	if len(desiredSlotCounts) > len(actualSlotCounts) {
-		for i := 0; i < len(desiredSlotCounts)-len(actualSlotCounts); i++ {
-			actualSlotCounts = append(actualSlotCounts, 0)
-		}
+	for len(actualSlotCounts) < len(desiredSlotCounts) {
+		actualSlotCounts = append(actualSlotCounts, 0)
 	}
 
 	sum := 0
@@ -285,39 +283,49 @@ func GenerateReshardingPlan(clusterNodesForShard map[int][]*ClusterNode, desired
 	receive := map[string]int{}
 	for i := range actualSlotCounts {
 		if actualSlotCounts[i] == desiredSlotCounts[i] {
-			//all is well
-		} else if actualSlotCounts[i] > desiredSlotCounts[i] {
+			// all is well
+			continue
+		}
+		primary, ok := primaries[i]
+		if !ok {
+			return nil, fmt.Errorf("no primary node found for shard %d", i)
+		}
+		if actualSlotCounts[i] > desiredSlotCounts[i] {
 			// need to get rid of:
-			delta := actualSlotCounts[i] - desiredSlotCounts[i]
-			rid[primaries[i].ID] = delta
-
-		} else if actualSlotCounts[i] < desiredSlotCounts[i] {
+			rid[primary.ID] = actualSlotCounts[i] - desiredSlotCounts[i]
+		} else {
 			// need to get:
-			delta := desiredSlotCounts[i] - actualSlotCounts[i]
-			receive[primaries[i].ID] = delta
+			receive[primary.ID] = desiredSlotCounts[i] - actualSlotCounts[i]
 		}
 	}
 
-	for fromID := range rid {
-		if rid[fromID] == 0 {
-			continue
-		}
-		for toID, receiveSlots := range receive {
-			if receiveSlots <= rid[fromID] {
-				actionPlan = append(actionPlan, Reshard{
-					FromID: fromID,
-					ToID:   toID,
-					Slots:  receiveSlots,
-				})
-				rid[fromID] = rid[fromID] - receiveSlots
-			} else {
-				actionPlan = append(actionPlan, Reshard{
-					FromID: fromID,
-					ToID:   toID,
-					Slots:  rid[fromID],
-				})
-				rid[fromID] = 0
+	donorIDs := make([]string, 0, len(rid))
+	for id := range rid {
+		donorIDs = append(donorIDs, id)
+	}
+	sort.Strings(donorIDs)
+	receiverIDs := make([]string, 0, len(receive))
+	for id := range receive {
+		receiverIDs = append(receiverIDs, id)
+	}
+	sort.Strings(receiverIDs)
+
+	for _, fromID := range donorIDs {
+		for _, toID := range receiverIDs {
+			if rid[fromID] == 0 {
+				break
 			}
+			if receive[toID] == 0 {
+				continue
+			}
+			slots := min(rid[fromID], receive[toID])
+			actionPlan = append(actionPlan, Reshard{
+				FromID: fromID,
+				ToID:   toID,
+				Slots:  slots,
+			})
+			rid[fromID] -= slots
+			receive[toID] -= slots
 		}
 	}
 

--- a/internal/controller/valkey/utils_test.go
+++ b/internal/controller/valkey/utils_test.go
@@ -372,6 +372,72 @@ func TestGenerateReshardingPlan(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Two donors and two receivers with uneven slot counts. The first
+			// donor drains before all receivers are satisfied, which used to
+			// produce zero-slot reshard steps and over-ship slots to the
+			// first receiver because satisfied receivers were never removed.
+			clusterNodesForShard: map[int][]*ClusterNode{
+				0: []*ClusterNode{
+					{
+						Pod:          "keyval-0-0",
+						IP:           "10.0.0.1",
+						ID:           "00000000000000000000",
+						MasterNodeID: "",
+						Flags:        []string{"master"},
+						SlotRanges:   []*ClusterSlotRange{{0, 7999}},
+					},
+				},
+				1: []*ClusterNode{
+					{
+						Pod:          "keyval-1-0",
+						IP:           "10.0.1.1",
+						ID:           "55555555555555555555",
+						MasterNodeID: "",
+						Flags:        []string{"master"},
+						SlotRanges:   []*ClusterSlotRange{{8000, 16383}},
+					},
+				},
+				2: []*ClusterNode{
+					{
+						Pod:          "keyval-2-0",
+						IP:           "10.0.2.1",
+						ID:           "99999999999999999999",
+						MasterNodeID: "",
+						Flags:        []string{"master"},
+						SlotRanges:   []*ClusterSlotRange{},
+					},
+				},
+				3: []*ClusterNode{
+					{
+						Pod:          "keyval-3-0",
+						IP:           "10.0.3.1",
+						ID:           "aaaaaaaaaaaaaaaaaaaa",
+						MasterNodeID: "",
+						Flags:        []string{"master"},
+						SlotRanges:   []*ClusterSlotRange{},
+					},
+				},
+			},
+			desiredShards: 4,
+			plan: []Reshard{
+				{
+					FromID: "00000000000000000000",
+					ToID:   "99999999999999999999",
+					Slots:  3904,
+				},
+				{
+					FromID: "55555555555555555555",
+					ToID:   "99999999999999999999",
+					Slots:  192,
+				},
+				{
+					FromID: "55555555555555555555",
+					ToID:   "aaaaaaaaaaaaaaaaaaaa",
+					Slots:  4096,
+				},
+			},
+		},
 	}
 	for _, tt := range testcases {
 		actual, err := GenerateReshardingPlan(tt.clusterNodesForShard, tt.desiredShards)

--- a/internal/controller/valkeycluster_controller_job.go
+++ b/internal/controller/valkeycluster_controller_job.go
@@ -71,6 +71,14 @@ func (m *ValkeyJobManager) getTargetPodAddress(ctx context.Context, valkeyCluste
 func (m *ValkeyJobManager) ReshardSlots(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, fromNodeID, toNodeID string, slotCount int) error {
 	logger := log.FromContext(ctx)
 
+	if slotCount <= 0 {
+		logger.Info("Skipping reshard with non-positive slot count",
+			"fromNodeID", fromNodeID,
+			"toNodeID", toNodeID,
+			"slotCount", slotCount)
+		return nil
+	}
+
 	logger.Info("Starting slot resharding via Job",
 		"fromNodeID", fromNodeID,
 		"toNodeID", toNodeID,


### PR DESCRIPTION
## Problem

Seen in production: the operator created a reshard Job that does nothing:

```
valkey-cli -a ... --cluster reshard 10.14.7.128:6379 \
  --cluster-from 00c02a5c1a84327dfae3719ccc4c2901114543 \
  --cluster-to 55f122df31f45e59e611548785aa4accc7f2924d \
  --cluster-slots 0 --cluster-yes
```

## Root cause

The donor/receiver matching loop in `GenerateReshardingPlan` had three bugs:

1. **Zero-slot steps** — when a donor's remaining balance hit 0 partway through the receiver loop, the `else` branch still emitted a `Reshard` step with `Slots: 0`, which became the no-op Job above.
2. **Over-shipping** — a receiver's outstanding need (`receive[toID]`) was never decremented as slots were assigned, so with multiple donors the same receiver kept getting slots after it was satisfied while other receivers were starved. Convergence only happened because the plan is regenerated every reconcile, moving slots more times than necessary.
3. **Broken zero-padding** — the padding loops re-evaluated `len(desired)-len(actual)` while appending, so scaling by ≥2 shards at once padded a single zero and silently dropped the remaining shard(s) from the plan.

Plans were also nondeterministic (built by iterating Go maps).

## Fix

- Match donors to receivers in sorted order, assigning `min(donor balance, receiver need)` and decrementing both sides — zero-slot steps are now impossible by construction and plans are deterministic.
- Build `actualSlotCounts` aligned by shard index (including primaries holding no slots), fixing the padding bug and a latent misattribution where a slot count could be compared against the wrong shard's primary.
- Return an error instead of nil-pointer panicking when a shard needing action has no primary.
- Defense in depth: `ReshardSlots` now logs and skips non-positive slot counts so a no-op Job can never be created regardless of the plan.

## Testing

- New regression unit test: two donors / two receivers with uneven counts — the old code emitted zero-slot steps and shipped the wrong amounts for this case.
- e2e against a local kind cluster: `should scale up` (1→3 shards) and `should scale down` (3→2), which exercise this code path end-to-end, pass with the fix.
- `golangci-lint` reports no new issues (all findings pre-exist on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)