### PR TITLE
Stop killing in-flight reshard Jobs and requeue on unsettled slot totals

### DIFF
--- a/internal/controller/valkey/utils.go
+++ b/internal/controller/valkey/utils.go
@@ -2,6 +2,7 @@ package valkey
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -11,6 +12,15 @@ import (
 
 	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
 )
+
+// ErrSlotsMigrationInFlight is returned by GenerateReshardingPlan when the
+// observed per-shard slot counts do not sum to exactly 16384. While a slot is
+// being migrated the importing node can claim it before the donor releases it
+// (or a slot can transiently have no owner), because each node reports its own
+// view of the cluster. This is not a failure of the cluster: callers should
+// requeue and re-plan once the migration has settled instead of treating it as
+// an error.
+var ErrSlotsMigrationInFlight = errors.New("slot totals do not sum to 16384")
 
 type ClusterNode struct {
 	Pod          string
@@ -275,7 +285,7 @@ func GenerateReshardingPlan(clusterNodesForShard map[int][]*ClusterNode, desired
 		sum = sum + c
 	}
 	if sum != 16384 {
-		return nil, fmt.Errorf("expected there to be 16384 total actual slots but got %v", actualSlotCounts)
+		return nil, fmt.Errorf("%w: observed per-shard slot counts %v", ErrSlotsMigrationInFlight, actualSlotCounts)
 	}
 
 	actionPlan := []Reshard{}

--- a/internal/controller/valkey/utils_test.go
+++ b/internal/controller/valkey/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSlotRanges(t *testing.T) {
@@ -443,6 +444,53 @@ func TestGenerateReshardingPlan(t *testing.T) {
 		actual, err := GenerateReshardingPlan(tt.clusterNodesForShard, tt.desiredShards)
 		assert.NoError(t, err)
 		assert.Equal(t, tt.plan, actual)
+	}
+}
+
+func TestGenerateReshardingPlanMigrationInFlight(t *testing.T) {
+	master := func(pod, id string, slotRanges ...*ClusterSlotRange) []*ClusterNode {
+		return []*ClusterNode{
+			{
+				Pod:        pod,
+				ID:         id,
+				Flags:      []string{"master"},
+				SlotRanges: slotRanges,
+			},
+		}
+	}
+
+	testcases := []struct {
+		name                 string
+		clusterNodesForShard map[int][]*ClusterNode
+		desiredShards        int
+	}{
+		{
+			// While a slot migrates, the importing primary can already claim it
+			// in its own CLUSTER NODES view before the donor releases it, so the
+			// per-shard counts sum to 16385.
+			name: "double counted slot during migration",
+			clusterNodesForShard: map[int][]*ClusterNode{
+				0: master("keyval-0-0", "00000000000000000000", &ClusterSlotRange{0, 8191}),
+				1: master("keyval-1-0", "55555555555555555555", &ClusterSlotRange{8191, 16383}),
+			},
+			desiredShards: 2,
+		},
+		{
+			// A slot can also transiently have no owner, summing to 16383.
+			name: "unowned slot during migration",
+			clusterNodesForShard: map[int][]*ClusterNode{
+				0: master("keyval-0-0", "00000000000000000000", &ClusterSlotRange{0, 8190}),
+				1: master("keyval-1-0", "55555555555555555555", &ClusterSlotRange{8192, 16383}),
+			},
+			desiredShards: 2,
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := GenerateReshardingPlan(tt.clusterNodesForShard, tt.desiredShards)
+			require.ErrorIs(t, err, ErrSlotsMigrationInFlight)
+			assert.Nil(t, plan)
+		})
 	}
 }
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -309,6 +310,13 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				log.Info(fmt.Sprintf("Removing %s from %s/%s", cn.ID, valkeyCluster.Namespace, valkeyCluster.Name))
 				err := jobMgr.DeleteNode(ctx, valkeyCluster, cn.ID)
 				if err != nil {
+					// A valkey-cli Job is still running; wait for it rather than failing.
+					if errors.Is(err, errValkeyCliJobStillRunning) {
+						log.Info("valkey-cli Job still running, requeueing before removing cluster node",
+							"nodeID", cn.ID,
+							"requeueAfter", "30s")
+						return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+					}
 					log.Error(err, "Failed to remove cluster node")
 					return ctrl.Result{}, err
 				}
@@ -991,6 +999,26 @@ func (r *ValkeyClusterReconciler) reconcileValkeySlots(ctx context.Context, valk
 		"name", valkeyCluster.Name,
 		"expectedShards", valkeyCluster.Spec.Shards)
 
+	// A valkey-cli Job from a previous reconcile may still be running, e.g. a
+	// reshard step that outlived waitForJobCompletion's wait. Reap finished
+	// leftovers, and if one is still running let it finish before planning or
+	// starting any other cluster operation against it.
+	runningJob, err := r.settleValkeyCliJobs(ctx, valkeyCluster, logger)
+	if err != nil {
+		logger.Error(err, "Failed to settle leftover valkey-cli Jobs")
+		return nil, err
+	}
+	if runningJob != nil {
+		// Log-only on purpose: this branch repeats every 30s while a long
+		// migration runs, so emitting an Event here would spam the cluster's
+		// event stream. Reshard steps that outlive the wait emit a one-off
+		// ValkeyCliJobRunning event when first detected below.
+		logger.Info("Waiting for still-running valkey-cli Job before reconciling slots",
+			"jobName", runningJob.Name,
+			"requeueAfter", "30s")
+		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	clusterNodesForShard, err := r.buildClusterNodesForShard(ctx, valkeyCluster)
 	if err != nil {
 		logger.Error(err, "Failed to build cluster nodes for shard")
@@ -1026,6 +1054,17 @@ func (r *ValkeyClusterReconciler) reconcileValkeySlots(ctx context.Context, valk
 
 	actionPlan, err := internalValkey.GenerateReshardingPlan(clusterNodesForShard, int(valkeyCluster.Spec.Shards))
 	if err != nil {
+		// Slot totals that don't sum to 16384 mean the nodes' views of slot
+		// ownership haven't settled (a migration is in flight), not that the
+		// cluster is broken. Wait and re-plan instead of failing the reconcile.
+		if errors.Is(err, internalValkey.ErrSlotsMigrationInFlight) {
+			logger.Info("Slot migration in flight, requeueing before generating a resharding plan",
+				"error", err,
+				"requeueAfter", "30s")
+			r.Recorder.Event(valkeyCluster, "Normal", "SlotMigrationInFlight",
+				"Observed slot totals != 16384, waiting for slot migration to settle before resharding")
+			return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
 		logger.Error(err, "Failed to generate resharding plan",
 			"shardCount", len(clusterNodesForShard),
 			"expectedShards", valkeyCluster.Spec.Shards)
@@ -1042,6 +1081,12 @@ func (r *ValkeyClusterReconciler) reconcileValkeySlots(ctx context.Context, valk
 
 		fixed, err := jobMgr.FixStuckSlotsIfNeeded(ctx, valkeyCluster, logger)
 		if err != nil {
+			// A valkey-cli Job is still running; wait for it rather than failing.
+			if errors.Is(err, errValkeyCliJobStillRunning) {
+				logger.Info("valkey-cli Job still running while fixing stuck slots, requeueing",
+					"requeueAfter", "30s")
+				return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
 			// Check if the error is due to cluster being down
 			if strings.Contains(err.Error(), "cluster is down during fix attempt") {
 				logger.Info("Cluster is down during fix, will retry",
@@ -1074,6 +1119,21 @@ func (r *ValkeyClusterReconciler) reconcileValkeySlots(ctx context.Context, valk
 
 		err := jobMgr.ReshardSlots(ctx, valkeyCluster, plan.FromID, plan.ToID, plan.Slots)
 		if err != nil {
+			// The reshard Job is still running: large steps routinely take longer
+			// than waitForJobCompletion is willing to block a reconcile for. The
+			// Job keeps migrating; requeue and pick it up on a later reconcile.
+			if errors.Is(err, errValkeyCliJobStillRunning) {
+				logger.Info("Reshard Job still running, requeueing to wait for it",
+					"stepIndex", idx,
+					"slots", plan.Slots,
+					"fromID", plan.FromID,
+					"toID", plan.ToID,
+					"requeueAfter", "30s")
+				r.Recorder.Event(valkeyCluster, "Normal", "ValkeyCliJobRunning",
+					fmt.Sprintf("Reshard of %d slots from %s to %s is still running, waiting for it to complete", plan.Slots, plan.FromID, plan.ToID))
+				return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+
 			// Check if the cluster is down - if so, delay and retry
 			if strings.Contains(err.Error(), "CLUSTERDOWN") {
 				logger.Info("Cluster is down during resharding, will retry",
@@ -1107,6 +1167,13 @@ func (r *ValkeyClusterReconciler) reconcileValkeySlots(ctx context.Context, valk
 
 		fixed, err := jobMgr.FixStuckSlotsIfNeeded(ctx, valkeyCluster, logger)
 		if err != nil {
+			// A valkey-cli Job is still running; wait for it rather than failing.
+			if errors.Is(err, errValkeyCliJobStillRunning) {
+				logger.Info("valkey-cli Job still running while fixing stuck slots after migration step, requeueing",
+					"stepIndex", idx,
+					"requeueAfter", "30s")
+				return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
 			// Check if the error is due to cluster being down
 			if strings.Contains(err.Error(), "cluster is down during fix attempt") {
 				logger.Info("Cluster is down during fix after migration, will retry",

--- a/internal/controller/valkeycluster_controller_job.go
+++ b/internal/controller/valkeycluster_controller_job.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -168,6 +169,13 @@ func (m *ValkeyJobManager) FixClusterSlots(ctx context.Context, valkeyCluster *c
 		"stderr", stderr)
 
 	if err != nil {
+		// The fix Job is still running (or another Job is): nothing has been
+		// verified yet, so surface that to the caller to requeue rather than
+		// running a concurrent check.
+		if errors.Is(err, errValkeyCliJobStillRunning) {
+			logger.Info("Fix Job is still running, caller should requeue and wait")
+			return err
+		}
 		// Check if the cluster is down during fix
 		if isClusterDown(stdout, stderr, err) {
 			logger.Info("Cluster is down during fix attempt, caller should retry")
@@ -262,6 +270,12 @@ func (m *ValkeyJobManager) FixStuckSlotsIfNeeded(ctx context.Context, valkeyClus
 	hasStuckSlots, checkErr := m.CheckForStuckSlots(ctx, valkeyCluster)
 
 	if checkErr != nil {
+		// The check could not run because a valkey-cli Job is still running, so
+		// we don't know whether slots are stuck. Propagate so the caller
+		// requeues and waits for the running Job instead.
+		if errors.Is(checkErr, errValkeyCliJobStillRunning) {
+			return false, checkErr
+		}
 		logger.Info("Check for stuck slots returned error",
 			"error", checkErr)
 	}

--- a/internal/controller/valkeycluster_controller_valkeycli_job.go
+++ b/internal/controller/valkeycluster_controller_valkeycli_job.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -21,10 +22,36 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// errValkeyCliJobStillRunning indicates a valkey-cli Job is still running: either
+// the Job this call created outlived the wait timeout, or a Job left behind by a
+// previous reconcile has not finished yet. The Job is intentionally left running —
+// deleting it would kill valkey-cli mid-operation (e.g. a slot migration) and leave
+// the cluster with stuck slots. Callers should requeue and let a later reconcile
+// pick up from wherever the Job got to.
+var errValkeyCliJobStillRunning = errors.New("valkey-cli Job is still running")
+
 // executeValkeyCliJob runs a valkey-cli command using a Kubernetes Job instead of exec.
 // This approach is more debuggable and doesn't consume resources on the valkey pods.
+//
+// Only one valkey-cli Job is allowed per cluster at a time: concurrent jobs could
+// race each other (e.g. a "--cluster fix" running against a live "--cluster reshard").
+// If a Job from a previous reconcile is still running, this returns
+// errValkeyCliJobStillRunning without creating a new Job.
 func (r *ValkeyClusterReconciler) executeValkeyCliJob(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, args []string) (string, string, error) {
 	logger := log.FromContext(ctx)
+
+	// Don't start a competing Job while one is still running for this cluster
+	// (reaping any finished leftovers from previous reconciles on the way).
+	running, err := r.settleValkeyCliJobs(ctx, valkeyCluster, logger)
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to check for running valkey-cli Jobs: %w", err)
+	}
+	if running != nil {
+		logger.Info("A valkey-cli Job for this cluster is still running, not creating another",
+			"runningJobName", running.Name,
+			"args", args)
+		return "", "", fmt.Errorf("%w: %s", errValkeyCliJobStillRunning, running.Name)
+	}
 
 	// Generate unique job name based on timestamp and operation
 	jobName := valkeyCliJobName(valkeyCluster.Name, time.Now().Unix())
@@ -43,6 +70,17 @@ func (r *ValkeyClusterReconciler) executeValkeyCliJob(ctx context.Context, valke
 	// Wait for Job to complete
 	stdout, stderr, err := r.waitForJobCompletion(ctx, valkeyCluster.Namespace, jobName, logger)
 
+	// If the Job is still running (wait timed out) or we can no longer tell
+	// (context cancelled, e.g. operator shutdown), leave it alone: deleting it
+	// would kill valkey-cli mid-operation. A later reconcile adopts or reaps it
+	// via settleValkeyCliJobs.
+	if errors.Is(err, errValkeyCliJobStillRunning) || ctx.Err() != nil {
+		logger.Info("Leaving valkey-cli Job running for a later reconcile to pick up",
+			"jobName", jobName,
+			"error", err)
+		return stdout, stderr, err
+	}
+
 	// Clean up the Job (best effort, don't fail if cleanup fails)
 	if cleanupErr := r.deleteJob(ctx, valkeyCluster.Namespace, jobName, logger); cleanupErr != nil {
 		logger.Info("Failed to cleanup Job (non-fatal)",
@@ -51,6 +89,77 @@ func (r *ValkeyClusterReconciler) executeValkeyCliJob(ctx context.Context, valke
 	}
 
 	return stdout, stderr, err
+}
+
+// valkeyCliJobLabels returns the labels applied to valkey-cli Jobs for the given
+// cluster, also used to find them again on later reconciles.
+func valkeyCliJobLabels(clusterName string) map[string]string {
+	return map[string]string{
+		"app":      "valkey-cluster-operator",
+		"cluster":  clusterName,
+		"job-type": "valkey-cli",
+	}
+}
+
+// isJobFinished reports whether a Job has run to completion (successfully or not).
+func isJobFinished(job *batchv1.Job) bool {
+	return job.Status.Succeeded > 0 || job.Status.Failed > 0
+}
+
+// leftoverJobLogTailBytes caps how much of a leftover Job's output is copied into
+// the operator's own log. Reshard Jobs that outlived the wait are exactly the ones
+// with large output, and the tail is what shows how the operation ended.
+const leftoverJobLogTailBytes = 4096
+
+// settleValkeyCliJobs looks for valkey-cli Jobs left behind by previous reconciles
+// (jobs that outlived waitForJobCompletion's timeout, or that were running when the
+// operator restarted). Finished leftovers have their output logged and are deleted.
+// If a leftover Job is still running it is returned so the caller can requeue and
+// wait for it instead of starting competing cluster operations.
+func (r *ValkeyClusterReconciler) settleValkeyCliJobs(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, logger logr.Logger) (*batchv1.Job, error) {
+	jobList := &batchv1.JobList{}
+	err := r.List(ctx, jobList,
+		client.InNamespace(valkeyCluster.Namespace),
+		client.MatchingLabels(valkeyCliJobLabels(valkeyCluster.Name)))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list valkey-cli Jobs: %w", err)
+	}
+
+	var running *batchv1.Job
+	for i := range jobList.Items {
+		job := &jobList.Items[i]
+		if !isJobFinished(job) {
+			logger.Info("Found valkey-cli Job from a previous reconcile that is still running",
+				"jobName", job.Name)
+			running = job
+			continue
+		}
+
+		// Finished leftover: capture its output for debugging, then reap it.
+		stdout, _, logsErr := r.getJobLogs(ctx, valkeyCluster.Namespace, job.Name, logger)
+		if logsErr != nil {
+			logger.Info("Could not retrieve logs from finished leftover valkey-cli Job (non-fatal)",
+				"jobName", job.Name,
+				"error", logsErr)
+		}
+		if len(stdout) > leftoverJobLogTailBytes {
+			stdout = "(truncated)..." + stdout[len(stdout)-leftoverJobLogTailBytes:]
+		}
+		logger.Info("Reaping finished valkey-cli Job from a previous reconcile",
+			"jobName", job.Name,
+			"succeeded", job.Status.Succeeded,
+			"failed", job.Status.Failed,
+			"stdout", stdout)
+		if job.DeletionTimestamp == nil {
+			if err := r.deleteJob(ctx, valkeyCluster.Namespace, job.Name, logger); err != nil {
+				logger.Info("Failed to delete finished leftover valkey-cli Job (non-fatal)",
+					"jobName", job.Name,
+					"error", err)
+			}
+		}
+	}
+
+	return running, nil
 }
 
 // maxJobNameLength caps Job names at 63 characters: Kubernetes copies the Job
@@ -91,22 +200,14 @@ func (r *ValkeyClusterReconciler) buildValkeyCliJob(jobName string, valkeyCluste
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: valkeyCluster.Namespace,
-			Labels: map[string]string{
-				"app":      "valkey-cluster-operator",
-				"cluster":  valkeyCluster.Name,
-				"job-type": "valkey-cli",
-			},
+			Labels:    valkeyCliJobLabels(valkeyCluster.Name),
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            &backoffLimit,
 			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app":      "valkey-cluster-operator",
-						"cluster":  valkeyCluster.Name,
-						"job-type": "valkey-cli",
-					},
+					Labels: valkeyCliJobLabels(valkeyCluster.Name),
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
@@ -140,7 +241,12 @@ func (r *ValkeyClusterReconciler) buildValkeyCliJob(jobName string, valkeyCluste
 	return job
 }
 
-// waitForJobCompletion waits for a Job to complete and returns its output
+// waitForJobCompletion waits for a Job to complete and returns its output.
+//
+// The timeout bounds how long a single reconcile blocks on the Job, not how long
+// the Job may run: on timeout this returns errValkeyCliJobStillRunning and the
+// Job keeps running. Long operations (e.g. reshard steps migrating large keyspaces)
+// are picked up again by later reconciles via settleValkeyCliJobs.
 func (r *ValkeyClusterReconciler) waitForJobCompletion(ctx context.Context, namespace, jobName string, logger logr.Logger) (string, string, error) {
 	timeout := 5 * time.Minute // Reduced timeout to avoid test timeouts
 	pollInterval := 2 * time.Second
@@ -148,7 +254,7 @@ func (r *ValkeyClusterReconciler) waitForJobCompletion(ctx context.Context, name
 
 	for {
 		if time.Now().After(deadline) {
-			return "", "", fmt.Errorf("Timeout waiting for Job %s to complete after %v", jobName, timeout)
+			return "", "", fmt.Errorf("%w: gave up waiting for Job %s after %v", errValkeyCliJobStillRunning, jobName, timeout)
 		}
 
 		// Get the Job
@@ -165,12 +271,12 @@ func (r *ValkeyClusterReconciler) waitForJobCompletion(ctx context.Context, name
 		}
 
 		// Check if Job completed
-		if job.Status.Succeeded > 0 {
-			logger.Info("Job completed successfully", "jobName", jobName)
-			return r.getJobLogs(ctx, namespace, jobName, logger)
-		}
+		if isJobFinished(job) {
+			if job.Status.Succeeded > 0 {
+				logger.Info("Job completed successfully", "jobName", jobName)
+				return r.getJobLogs(ctx, namespace, jobName, logger)
+			}
 
-		if job.Status.Failed > 0 {
 			logger.Info("Job failed", "jobName", jobName)
 			stdout, stderr, _ := r.getJobLogs(ctx, namespace, jobName, logger)
 			return stdout, stderr, fmt.Errorf("Job %s failed", jobName)

--- a/internal/controller/valkeycluster_controller_valkeycli_job_test.go
+++ b/internal/controller/valkeycluster_controller_valkeycli_job_test.go
@@ -1,11 +1,18 @@
 package controller
 
 import (
+	"errors"
 	"strings"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
 )
 
 var _ = Describe("valkeyCliJobName", func() {
@@ -40,5 +47,125 @@ var _ = Describe("valkeyCliJobName", func() {
 		Expect(len(name)).To(BeNumerically("<=", maxJobNameLength))
 		Expect(validation.IsDNS1123Label(name)).To(BeEmpty())
 		Expect(name).NotTo(ContainSubstring("--"))
+	})
+})
+
+var _ = Describe("isJobFinished", func() {
+	It("reports an in-flight Job as not finished", func() {
+		Expect(isJobFinished(&batchv1.Job{})).To(BeFalse())
+		Expect(isJobFinished(&batchv1.Job{Status: batchv1.JobStatus{Active: 1}})).To(BeFalse())
+	})
+
+	It("reports succeeded and failed Jobs as finished", func() {
+		Expect(isJobFinished(&batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}})).To(BeTrue())
+		Expect(isJobFinished(&batchv1.Job{Status: batchv1.JobStatus{Failed: 1}})).To(BeTrue())
+	})
+})
+
+var _ = Describe("valkey-cli Job tracking across reconciles", func() {
+	// Note: envtest runs only the API server, so created Jobs never get pods and
+	// never progress on their own; tests drive Job status transitions manually.
+	// Foreground deletion also never completes (no garbage collector), so
+	// deletion is asserted via DeletionTimestamp rather than absence.
+
+	newReconciler := func() *ValkeyClusterReconciler {
+		return &ValkeyClusterReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	}
+
+	newCluster := func(name string) *cachev1alpha1.ValkeyCluster {
+		return &cachev1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+				Image:    "valkey/valkey:8.0.2",
+			},
+		}
+	}
+
+	createJob := func(r *ValkeyClusterReconciler, valkeyCluster *cachev1alpha1.ValkeyCluster, timestamp int64) *batchv1.Job {
+		job := r.buildValkeyCliJob(
+			valkeyCliJobName(valkeyCluster.Name, timestamp),
+			valkeyCluster,
+			[]string{"--cluster", "check", "127.0.0.1:6379"})
+		Expect(k8sClient.Create(ctx, job)).To(Succeed())
+		return job
+	}
+
+	markSucceeded := func(job *batchv1.Job) {
+		job.Status.Succeeded = 1
+		Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+	}
+
+	markFailed := func(job *batchv1.Job) {
+		job.Status.Failed = 1
+		Expect(k8sClient.Status().Update(ctx, job)).To(Succeed())
+	}
+
+	listJobs := func(valkeyCluster *cachev1alpha1.ValkeyCluster) []batchv1.Job {
+		jobList := &batchv1.JobList{}
+		Expect(k8sClient.List(ctx, jobList,
+			client.InNamespace(valkeyCluster.Namespace),
+			client.MatchingLabels(valkeyCliJobLabels(valkeyCluster.Name)))).To(Succeed())
+		return jobList.Items
+	}
+
+	Describe("executeValkeyCliJob", func() {
+		It("does not create a competing Job while one is still running", func() {
+			r := newReconciler()
+			valkeyCluster := newCluster("track-exec")
+
+			createJob(r, valkeyCluster, 1789000001)
+
+			_, _, err := r.executeValkeyCliJob(ctx, valkeyCluster, []string{"--cluster", "check", "127.0.0.1:6379"})
+			Expect(errors.Is(err, errValkeyCliJobStillRunning)).To(BeTrue())
+			Expect(listJobs(valkeyCluster)).To(HaveLen(1))
+		})
+	})
+
+	Describe("settleValkeyCliJobs", func() {
+		It("reaps finished leftovers and reports a still-running one", func() {
+			r := newReconciler()
+			valkeyCluster := newCluster("track-settle")
+			otherCluster := newCluster("track-settle-other")
+
+			running := createJob(r, valkeyCluster, 1789000001)
+			finished := createJob(r, valkeyCluster, 1789000002)
+			markFailed(finished)
+			// Another cluster's running Job must not be picked up.
+			otherRunning := createJob(r, otherCluster, 1789000003)
+
+			found, err := r.settleValkeyCliJobs(ctx, valkeyCluster, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).NotTo(BeNil())
+			Expect(found.Name).To(Equal(running.Name))
+
+			// The still-running Job must NOT have been deleted.
+			runningAfter := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(running), runningAfter)).To(Succeed())
+			Expect(runningAfter.DeletionTimestamp).To(BeNil())
+
+			// The finished leftover has been reaped.
+			finishedAfter := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(finished), finishedAfter)).To(Succeed())
+			Expect(finishedAfter.DeletionTimestamp).NotTo(BeNil())
+
+			// The other cluster's Job is untouched.
+			otherAfter := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(otherRunning), otherAfter)).To(Succeed())
+			Expect(otherAfter.DeletionTimestamp).To(BeNil())
+
+			// Once the running Job finishes, nothing is reported as running.
+			markSucceeded(running)
+			found, err = r.settleValkeyCliJobs(ctx, valkeyCluster, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
## Problem

During a large reshard, a single `valkey-cli --cluster reshard` step can run far longer than `waitForJobCompletion` is willing to block a reconcile for. Previously the operator deleted the still-running Job at that timeout, killing valkey-cli mid-slot-migration, and then treated the resulting mid-migration slot counts (sum != 16384) as a planning error.

## Changes

- **The wait timeout no longer kills the Job.** `waitForJobCompletion`'s timeout now only bounds how long one reconcile blocks: on timeout the Job is left running and `errValkeyCliJobStillRunning` is returned, turning into a 30s requeue instead of a reconcile failure. The same applies when the operator shuts down mid-wait (context cancelled).
- **Jobs are tracked across reconciles via their labels.** A new `settleValkeyCliJobs` reaps finished leftover Jobs (logging a tail of their output for debugging) and reports a still-running one so the reconcile requeues instead of starting competing cluster operations.
- **Only one valkey-cli Job per cluster at a time.** `executeValkeyCliJob` refuses to start a second concurrent Job for the same cluster, preventing e.g. a `--cluster fix` racing a live `--cluster reshard`.
- **Unsettled slot totals are no longer a planning error.** `GenerateReshardingPlan` returns `ErrSlotsMigrationInFlight` when observed slot totals != 16384 (a slot can transiently be double-counted or unowned while migrating), which the controller turns into a 30s requeue.

## Testing

- New unit tests for `GenerateReshardingPlan` returning `ErrSlotsMigrationInFlight` on double-counted and unowned slots.
- New envtest specs covering `settleValkeyCliJobs` (reaps finished leftovers, reports running ones, ignores other clusters' Jobs) and `executeValkeyCliJob` refusing to create a competing Job.
- `make test` passes; golangci-lint introduces no new issues over the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)