### PR TITLE
Manage spec.valkeyConfig declaratively: live apply, drift convergence, restarts, fleet defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
-	go test --timeout=30m ./test/e2e/ -v -ginkgo.v
+	go test --timeout=45m ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@ resource definition that can be used to deploy a Valkey cluster in a Kubernetes
 environment.
 
 The operator provides the following features:
+
 - Scaling up and down of CPU, memory and storage sizes.
 - Scaling up and down the number of replicas per shard in the cluster
 - Resharding up and down, you can change the number of shards in a cluster and
 the Operator will handle resharding the slots for you.
 - Automatic disk scaling: disk usage is monitored and volumes grow on their own,
 so users don't need to think about disk sizes at all.
+- Declarative Valkey config management: `spec.valkeyConfig.parameters` are
+live-applied to running pods (no restart needed for runtime-settable
+directives), runtime drift converges back to spec, and directives that cannot
+be set at runtime are applied through a health-gated rolling restart.
 
 What is **NOT** implemented:
+
 - Services. The only way to connect to the Valkey cluster is via the pod IP.
 
 ## Disk auto-scaling
@@ -39,12 +45,61 @@ and sets the `StorageLimited` status condition; the condition clears once usage
 drops back below the threshold or the limit is raised.
 
 Notes:
+
 - Volume expansion requires a StorageClass with `allowVolumeExpansion: true`
   (for example AWS EBS gp3). On storage classes without it (such as kind's
   local-path provisioner) the operator sets the `StorageLimited` condition once
   and disables auto-scaling for the cluster, including the usage measurements.
 - AWS EBS allows one modification per volume per ~6 hours; the operator waits
   for an expansion to complete before requesting another one.
+
+## Valkey configuration management
+
+`valkey-server` reads its config file once at process start, and the config
+file is mounted from a ConfigMap via `subPath`, so running pods never see file
+updates. The operator therefore manages config in both directions:
+
+- **Live apply.** Every reconcile, each directive in
+  `spec.valkeyConfig.parameters` is checked against every running pod
+  (`CONFIG GET`, compared semantically — memory values and
+  `client-output-buffer-limit` classes are normalised) and applied with
+  `CONFIG SET` when it differs. Declarative changes reach running pods without
+  restarts, and manual `CONFIG SET` drift (e.g. incident remediation) converges
+  back to spec instead of silently reverting on the next pod restart.
+- **Health-gated restart fallback.** A directive the server rejects with
+  "can't set immutable config" (or "can't set protected config") can only be
+  applied by a restart onto the updated config file. Such pods are restarted
+  one at a time, gated on full cluster health including replica catch-up (the
+  same discipline as image rolling updates), replicas before primaries.
+- **Rejected values do not restart pods.** A directive the server rejects for
+  its *value* (e.g. `repl-backlog-size banana`) is surfaced as a warning event
+  and skipped: the same value sits in the config file, and valkey refuses to
+  boot on an invalid file directive, so restarting would trade a running pod
+  for a crash-looping one. Directives the server does not recognise at all are
+  likewise skipped with a warning.
+- **`rawConfig` changes still require a restart.** The live-apply path manages
+  only name/value `parameters` (and the operator defaults); an edit to
+  `spec.valkeyConfig.rawConfig` updates the ConfigMap but takes effect only as
+  pods restart.
+
+### Operator-managed defaults
+
+For clusters **not** using `spec.valkeyConfig.rawConfig` (raw config is expert
+mode — the operator does not layer defaults it cannot see overridden) and whose
+image tag positively parses as Valkey >= 8.0, the operator applies
+replication-tuning defaults, derived from the pod memory limit:
+
+| Directive | Default | Rationale |
+|---|---|---|
+| `dual-channel-replication-enabled` | `yes` | Moves full-sync buffering off the primary, structurally avoiding the primary-side output-buffer overrun that kills full syncs of large shards. |
+| `repl-backlog-size` | `clamp(memory/16, 10MiB, 512MiB)` | The compiled-in 10MiB is seconds of backlog on a busy shard; too small a backlog turns every transient disconnect into a full resync. |
+| `client-output-buffer-limit` | `replica clamp(memory/2, 64MiB, 4GiB) <hard/2> 120` | The compiled-in 256MiB hard limit kills full syncs of multi-GiB shards; conversely 256MiB exceeds the whole pod on small caches. |
+
+`spec.valkeyConfig.parameters` entries are applied after the defaults, so a
+per-cluster value always overrides the fleet default. The defaults were sized
+from the SP-1527 incident (a 9.4GB shard at ~5.4MB/s of replication write
+traffic stuck in a full-resync crash loop for ~6 hours under the compiled-in
+defaults).
 
 ## Prerequisites
 
@@ -98,5 +153,5 @@ $ dagger call build-and-load-locally --sock /var/run/docker.sock
 Once done, you'll want to execute the following command to run the e2e test suite:
 
 ```console
-$ dagger call e-2-e-test --sock /var/run/docker.sock
+dagger call e-2-e-test --sock /var/run/docker.sock
 ```

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -217,7 +217,9 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	// We may add the option to force a restart in future using the hash of the updated valkey config
+	// Config changes are applied to running pods by reconcileValkeyConfig
+	// below; directives that cannot be set at runtime are applied by a
+	// health-gated rolling restart (performConfigRestarts) onto this file.
 	_, err = r.upsertConfigMap(ctx, valkeyCluster)
 	if err != nil {
 		log.Error(err, "Failed to upsert configmap")
@@ -254,6 +256,17 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// authenticated while pods restart with the new config file.
 	if err := r.reconcileAuth(ctx, valkeyCluster); err != nil {
 		log.Error(err, "Failed to reconcile auth config")
+		return ctrl.Result{}, err
+	}
+
+	// Live-apply the managed config directives (spec.valkeyConfig) to running
+	// pods and collect any pods that need a restart for directives the server
+	// cannot set at runtime. The restarts themselves are driven at the end of
+	// the reconcile (performConfigRestarts), after any in-flight revision
+	// rollout has priority.
+	podsNeedingConfigRestart, err := r.reconcileValkeyConfig(ctx, valkeyCluster)
+	if err != nil {
+		log.Error(err, "Failed to reconcile valkey config")
 		return ctrl.Result{}, err
 	}
 
@@ -786,6 +799,19 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	res, err = r.performRollingUpdate(ctx, valkeyCluster)
 	if err != nil {
 		log.Error(err, "Failed to perform rolling update")
+		return ctrl.Result{}, err
+	}
+	if res != nil {
+		return *res, nil
+	}
+
+	// Restart pods whose runtime config cannot converge to spec via CONFIG SET
+	// (immutable directives), one pod at a time, gated on cluster health. Runs
+	// after performRollingUpdate so a revision rollout — which also restarts
+	// pods onto the current config file — always takes priority.
+	res, err = r.performConfigRestarts(ctx, valkeyCluster, podsNeedingConfigRestart)
+	if err != nil {
+		log.Error(err, "Failed to perform config restarts")
 		return ctrl.Result{}, err
 	}
 	if res != nil {

--- a/internal/controller/valkeycluster_controller_config.go
+++ b/internal/controller/valkeycluster_controller_config.go
@@ -114,19 +114,82 @@ func podMemoryLimitBytes(valkeyCluster *cachev1alpha1.ValkeyCluster) int64 {
 
 // managedConfigEntries returns the ordered list of config directives the
 // operator actively manages on running pods: the operator-wide defaults
-// followed by the spec's valkeyConfig.parameters. Entries are applied in
-// order; for directives where the same name appears more than once (e.g.
-// client-output-buffer-limit once per client class), later entries win for
-// the class/value they address, matching valkey.conf semantics — so spec
-// parameters override the defaults. getValkeyConfigContent renders the same
-// entries in the same order into the config file, keeping the live-applied
-// state and the restart state identical.
+// followed by the spec's valkeyConfig.parameters. For directives where the
+// same name appears more than once (e.g. client-output-buffer-limit once per
+// client class), later entries win for the class/value they address,
+// matching valkey.conf semantics — so spec parameters override the defaults.
+// getValkeyConfigContent renders these entries in this order into the config
+// file (where the server applies last-line-wins at boot), and
+// reconcileValkeyConfig live-applies their effectiveManagedConfig collapse,
+// keeping the live-applied state and the restart state identical.
 func managedConfigEntries(valkeyCluster *cachev1alpha1.ValkeyCluster) []cachev1alpha1.ValkeyConfigParameter {
 	entries := managedDefaultParameters(valkeyCluster)
 	if valkeyCluster.Spec.ValkeyConfig != nil {
 		entries = append(entries, valkeyCluster.Spec.ValkeyConfig.Parameters...)
 	}
 	return entries
+}
+
+// effectiveManagedConfig collapses the ordered managed entries into a single
+// effective desired value per directive, later entries overriding earlier
+// ones — the state a pod restart would produce from the rendered config file
+// (last line wins in valkey.conf). The live-apply path must work on this
+// collapsed form: each raw entry is compared against a config snapshot taken
+// once per pod, so applying the raw list would flip a directive that appears
+// in both the defaults and the spec (e.g. an overridden repl-backlog-size)
+// between the two values on alternating reconciles, never settling.
+//
+// client-output-buffer-limit is merged per client class rather than replaced
+// wholesale, mirroring how one config-file line per class composes.
+func effectiveManagedConfig(entries []cachev1alpha1.ValkeyConfigParameter) []cachev1alpha1.ValkeyConfigParameter {
+	effective := make([]cachev1alpha1.ValkeyConfigParameter, 0, len(entries))
+	index := make(map[string]int, len(entries))
+	for _, e := range entries {
+		i, seen := index[e.Name]
+		if !seen {
+			index[e.Name] = len(effective)
+			effective = append(effective, e)
+			continue
+		}
+		if e.Name == "client-output-buffer-limit" {
+			effective[i].Value = mergeClientOutputBufferLimit(effective[i].Value, e.Value)
+			continue
+		}
+		effective[i].Value = e.Value
+	}
+	return effective
+}
+
+// mergeClientOutputBufferLimit overlays the classes present in the override
+// value onto the base value, keeping base classes the override does not
+// mention. If either value does not parse as "class hard soft seconds"
+// groups the override wins wholesale — the server will reject it and the
+// error surfaces through the rejected-directive path.
+func mergeClientOutputBufferLimit(base, override string) string {
+	baseFields := strings.Fields(base)
+	overrideFields := strings.Fields(override)
+	if len(overrideFields) == 0 || len(overrideFields)%4 != 0 || len(baseFields)%4 != 0 {
+		return override
+	}
+	var classOrder []string
+	classes := map[string][]string{}
+	for _, fields := range [][]string{baseFields, overrideFields} {
+		for i := 0; i+3 < len(fields); i += 4 {
+			class := strings.ToLower(fields[i])
+			if class == "slave" {
+				class = "replica"
+			}
+			if _, ok := classes[class]; !ok {
+				classOrder = append(classOrder, class)
+			}
+			classes[class] = fields[i+1 : i+4]
+		}
+	}
+	parts := make([]string, 0, len(classOrder))
+	for _, class := range classOrder {
+		parts = append(parts, class+" "+strings.Join(classes[class], " "))
+	}
+	return strings.Join(parts, " ")
 }
 
 // reconcileValkeyConfig live-applies the managed config directives to every
@@ -149,18 +212,14 @@ func managedConfigEntries(valkeyCluster *cachev1alpha1.ValkeyCluster) []cachev1a
 func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster) ([]corev1.Pod, error) {
 	logger := log.FromContext(ctx)
 
-	entries := managedConfigEntries(valkeyCluster)
+	entries := effectiveManagedConfig(managedConfigEntries(valkeyCluster))
 	if len(entries) == 0 {
 		return nil, nil
 	}
 
 	names := make([]string, 0, len(entries))
-	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if !seen[e.Name] {
-			seen[e.Name] = true
-			names = append(names, e.Name)
-		}
+		names = append(names, e.Name)
 	}
 
 	podList := &corev1.PodList{}
@@ -172,11 +231,13 @@ func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, val
 		return nil, err
 	}
 
-	// Persistent conditions (unknown directives, rejected values, restart
-	// required) are aggregated and evented once per directive per reconcile
-	// rather than once per pod: client-go's event spam filter budgets by
-	// involved object, so per-pod repeats would starve the cluster's whole
-	// event stream.
+	// Everything evented here — successful applies included — is aggregated
+	// and evented once per directive per reconcile rather than once per pod:
+	// client-go's event spam filter budgets by involved object (burst of 25,
+	// refilling one per 5 minutes), so per-pod repeats (e.g. a fleet-defaults
+	// rollout touching every pod of a large cluster in one reconcile) would
+	// starve the cluster's whole event stream.
+	appliedDirectives := map[string]int{}
 	unknownDirectives := map[string]int{}
 	rejectedDirectives := map[string]string{}
 	restartDirectives := map[string]string{}
@@ -218,8 +279,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, val
 			if err == nil {
 				logger.Info("Applied config directive to running pod",
 					"pod", pod.Name, "directive", e.Name, "value", e.Value)
-				r.Recorder.Event(valkeyCluster, "Normal", "ConfigUpdated",
-					fmt.Sprintf("Applied %s to pod %s", e.Name, pod.Name))
+				appliedDirectives[e.Name]++
 				continue
 			}
 			if _, isServerErr := valkey.IsValkeyErr(err); isServerErr {
@@ -238,6 +298,10 @@ func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, val
 		}
 	}
 
+	for name, count := range appliedDirectives {
+		r.Recorder.Event(valkeyCluster, "Normal", "ConfigUpdated",
+			fmt.Sprintf("Applied %s to %d pod(s)", name, count))
+	}
 	for name, count := range unknownDirectives {
 		logger.Info("Skipping config directive unknown to running server",
 			"directive", name, "pods", count)

--- a/internal/controller/valkeycluster_controller_config.go
+++ b/internal/controller/valkeycluster_controller_config.go
@@ -1,0 +1,390 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
+	"github.com/valkey-io/valkey-go"
+)
+
+// Replication-tuning default bounds. Sizing rationale lives in the README's
+// "Operator-managed defaults" table; values sized per the SP-1527 incident.
+const (
+	// managedDefaultReplBacklogMin is Valkey's compiled-in default (10mb).
+	managedDefaultReplBacklogMin = int64(10 * 1024 * 1024)
+	managedDefaultReplBacklogMax = int64(512 * 1024 * 1024)
+	managedDefaultReplicaHardMin = int64(64 * 1024 * 1024)
+	managedDefaultReplicaHardMax = int64(4 * 1024 * 1024 * 1024)
+	// managedDefaultReplicaSoftSeconds is the soft-limit window (compiled
+	// default is 60s).
+	managedDefaultReplicaSoftSeconds = 120
+)
+
+// managedDefaultParameters returns the operator-wide replication-tuning
+// defaults, derived from the cluster's pod memory limit. Sizing rationale:
+// README, "Operator-managed defaults". They are returned only when:
+//
+//   - spec.valkeyConfig.rawConfig is empty. A raw config replaces the
+//     operator's default config file wholesale — expert mode — so the
+//     operator does not layer defaults it cannot see overridden.
+//   - the image tag parses as Valkey >= 8.0, the version that introduced
+//     dual-channel-replication-enabled (absent from valkey 7.2's valkey.conf,
+//     documented in 8.0.5's). Rendering a directive an older server does not
+//     recognise into the config file would stop pods from booting (verified
+//     on ghcr.io/halter/valkey-server:8.0.5: an unknown file directive exits
+//     1 with "Bad directive or wrong number of arguments"). Unparseable tags
+//     (digest pins, non-numeric tags) get no defaults — the safe direction:
+//     behaviour is unchanged from operator versions before this.
+//
+// spec.valkeyConfig.parameters entries are appended after these (both in the
+// config file and in the live-apply order), so a per-cluster value always
+// overrides the fleet default.
+func managedDefaultParameters(valkeyCluster *cachev1alpha1.ValkeyCluster) []cachev1alpha1.ValkeyConfigParameter {
+	if valkeyCluster.Spec.ValkeyConfig != nil && valkeyCluster.Spec.ValkeyConfig.RawConfig != "" {
+		return nil
+	}
+	if !imageSupportsManagedDefaults(valkeyCluster.Spec.Image) {
+		return nil
+	}
+
+	defaults := []cachev1alpha1.ValkeyConfigParameter{
+		{Name: "dual-channel-replication-enabled", Value: "yes"},
+	}
+
+	memoryLimit := podMemoryLimitBytes(valkeyCluster)
+	if memoryLimit <= 0 {
+		// No sizing basis — leave the sized directives at compiled defaults.
+		return defaults
+	}
+
+	backlog := min(max(memoryLimit/16, managedDefaultReplBacklogMin), managedDefaultReplBacklogMax)
+
+	// The replica hard limit must stay above repl-backlog-size (a replica
+	// limit below it is ignored, per valkey.conf 8.0.5); with memory/16 vs
+	// memory/2 and these clamp ranges, backlog <= hard holds for every
+	// memory value.
+	hard := min(max(memoryLimit/2, managedDefaultReplicaHardMin), managedDefaultReplicaHardMax)
+	soft := hard / 2
+
+	return append(defaults,
+		cachev1alpha1.ValkeyConfigParameter{Name: "repl-backlog-size", Value: strconv.FormatInt(backlog, 10)},
+		cachev1alpha1.ValkeyConfigParameter{Name: "client-output-buffer-limit", Value: fmt.Sprintf("replica %d %d %d", hard, soft, managedDefaultReplicaSoftSeconds)},
+	)
+}
+
+// imageSupportsManagedDefaults reports whether the image tag positively
+// parses as Valkey >= 8.0. Tags like "ghcr.io/halter/valkey-server:8.0.5",
+// "ghcr.io/halter/valkey:8.0.2" and "...:8.1.9" qualify. Anything that does
+// not parse (no tag, digest pins, non-numeric tags) is treated as
+// unsupported so no directive lands in a config file that an unknown server
+// version might refuse to boot with.
+func imageSupportsManagedDefaults(image string) bool {
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 || strings.Contains(image[idx:], "/") {
+		return false
+	}
+	tag := strings.TrimPrefix(image[idx+1:], "v")
+	parts := strings.SplitN(tag, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	if _, err := strconv.Atoi(parts[1]); err != nil {
+		return false
+	}
+	return major >= 8
+}
+
+func podMemoryLimitBytes(valkeyCluster *cachev1alpha1.ValkeyCluster) int64 {
+	if valkeyCluster.Spec.Resources == nil {
+		return 0
+	}
+	return valkeyCluster.Spec.Resources.Limits.Memory().Value()
+}
+
+// managedConfigEntries returns the ordered list of config directives the
+// operator actively manages on running pods: the operator-wide defaults
+// followed by the spec's valkeyConfig.parameters. Entries are applied in
+// order; for directives where the same name appears more than once (e.g.
+// client-output-buffer-limit once per client class), later entries win for
+// the class/value they address, matching valkey.conf semantics — so spec
+// parameters override the defaults. getValkeyConfigContent renders the same
+// entries in the same order into the config file, keeping the live-applied
+// state and the restart state identical.
+func managedConfigEntries(valkeyCluster *cachev1alpha1.ValkeyCluster) []cachev1alpha1.ValkeyConfigParameter {
+	entries := managedDefaultParameters(valkeyCluster)
+	if valkeyCluster.Spec.ValkeyConfig != nil {
+		entries = append(entries, valkeyCluster.Spec.ValkeyConfig.Parameters...)
+	}
+	return entries
+}
+
+// reconcileValkeyConfig live-applies the managed config directives to every
+// running pod via CONFIG GET -> compare -> CONFIG SET, generalising the
+// reconcileAuth pattern. The config file (ConfigMap) only takes effect on pod
+// restart — and the ConfigMap is mounted via subPath, so running pods never
+// even see file updates. Without the live apply, a spec.valkeyConfig change
+// goes nowhere until pods happen to restart, and manual CONFIG SET drift
+// (e.g. incident remediation) silently reverts on any restart with nothing
+// converging it back. Running this every reconcile gives both directions:
+// declarative changes reach running pods without restarts, and runtime drift
+// on managed directives converges back to spec.
+//
+// Directives that the server rejects at runtime (immutable configs) are
+// collected per pod and returned so the caller can drive a health-gated
+// rolling restart; pods restart onto the already-updated config file.
+// Directives unknown to the running server version are skipped with a warning
+// — a restart would not help and the unknown directive in the config file
+// would prevent the pod from booting at all.
+func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster) ([]corev1.Pod, error) {
+	logger := log.FromContext(ctx)
+
+	entries := managedConfigEntries(valkeyCluster)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if !seen[e.Name] {
+			seen[e.Name] = true
+			names = append(names, e.Name)
+		}
+	}
+
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(valkeyCluster.Namespace),
+		client.MatchingLabels(labelsForValkeyCluster(valkeyCluster.Name)),
+	}
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	// Persistent conditions (unknown directives, rejected values, restart
+	// required) are aggregated and evented once per directive per reconcile
+	// rather than once per pod: client-go's event spam filter budgets by
+	// involved object, so per-pod repeats would starve the cluster's whole
+	// event stream.
+	unknownDirectives := map[string]int{}
+	rejectedDirectives := map[string]string{}
+	restartDirectives := map[string]string{}
+
+	var podsNeedingRestart []corev1.Pod
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+			continue
+		}
+		valkeyClient, err := r.NewValkeyClient(ctx, valkeyCluster, pod.Status.PodIP, VALKEY_PORT)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create valkey client for pod %s: %w", pod.Name, err)
+		}
+		defer valkeyClient.Close()
+
+		current, err := valkeyClient.Do(ctx, valkeyClient.B().ConfigGet().Parameter(names...).Build()).AsStrMap()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config from pod %s: %w", pod.Name, err)
+		}
+
+		needsRestart := false
+		for _, e := range entries {
+			currentValue, known := current[e.Name]
+			if !known {
+				// CONFIG GET omits directives this server version does not
+				// recognise. Don't restart for it: the directive is also in
+				// the config file, and an unknown file directive would stop
+				// the recreated pod from booting.
+				unknownDirectives[e.Name]++
+				continue
+			}
+			if valkeyConfigValueEqual(e.Name, e.Value, currentValue) {
+				continue
+			}
+			err := valkeyClient.Do(ctx, valkeyClient.B().ConfigSet().
+				ParameterValue().
+				ParameterValue(e.Name, e.Value).
+				Build()).Error()
+			if err == nil {
+				logger.Info("Applied config directive to running pod",
+					"pod", pod.Name, "directive", e.Name, "value", e.Value)
+				r.Recorder.Event(valkeyCluster, "Normal", "ConfigUpdated",
+					fmt.Sprintf("Applied %s to pod %s", e.Name, pod.Name))
+				continue
+			}
+			if _, isServerErr := valkey.IsValkeyErr(err); isServerErr {
+				if isConfigSetRestartableError(err) {
+					restartDirectives[e.Name] = err.Error()
+					needsRestart = true
+				} else {
+					rejectedDirectives[e.Name] = err.Error()
+				}
+				continue
+			}
+			return nil, fmt.Errorf("failed to set config %s on pod %s: %w", e.Name, pod.Name, err)
+		}
+		if needsRestart {
+			podsNeedingRestart = append(podsNeedingRestart, pod)
+		}
+	}
+
+	for name, count := range unknownDirectives {
+		logger.Info("Skipping config directive unknown to running server",
+			"directive", name, "pods", count)
+		r.Recorder.Event(valkeyCluster, "Warning", "ConfigDirectiveUnknown",
+			fmt.Sprintf("Directive %q is not recognised by the valkey server (%d pods); skipping live apply", name, count))
+	}
+	for name, errText := range rejectedDirectives {
+		logger.Info("Config directive rejected by server, not restarting",
+			"directive", name, "error", errText)
+		r.Recorder.Event(valkeyCluster, "Warning", "ConfigValueRejected",
+			fmt.Sprintf("CONFIG SET %s rejected (%s); fix the value in spec.valkeyConfig — pods restarted with this value in the config file may fail to boot", name, errText))
+	}
+	for name, errText := range restartDirectives {
+		logger.Info("Config directive not settable at runtime, scheduling rolling restart",
+			"directive", name, "error", errText, "pods", len(podsNeedingRestart))
+		r.Recorder.Event(valkeyCluster, "Warning", "ConfigRequiresRestart",
+			fmt.Sprintf("%s cannot be set at runtime (%s); applying via health-gated rolling restart of %d pods", name, errText, len(podsNeedingRestart)))
+	}
+
+	return podsNeedingRestart, nil
+}
+
+// isConfigSetRestartableError reports whether a CONFIG SET server rejection
+// means the directive can only be applied by restarting the pod onto the
+// updated config file. Valkey formats these rejections as "... can't set
+// immutable config" and "... can't set protected config" — both file-settable
+// classes (the errstr ternary in configSetCommand,
+// https://github.com/valkey-io/valkey/blob/8.0.5/src/config.c).
+// Every other rejection is treated as a value error, for which the caller
+// must NOT restart: the same value sits in the rendered config file, and
+// valkey 8.0.5 refuses to boot on an invalid file directive (verified against
+// ghcr.io/halter/valkey-server:8.0.5), so restarting would trade a
+// running-but-stale pod for a crash-looping one.
+func isConfigSetRestartableError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "can't set immutable config") ||
+		strings.Contains(msg, "can't set protected config")
+}
+
+// valkeyConfigValueEqual reports whether a desired config value and the value
+// CONFIG GET returned are semantically equal. CONFIG GET canonicalises values
+// (memory sizes come back as plain byte counts, client-output-buffer-limit
+// comes back as the full three-class string), so a plain string compare would
+// report perpetual mismatches and re-SET on every reconcile.
+func valkeyConfigValueEqual(name, desired, current string) bool {
+	d := strings.TrimSpace(desired)
+	c := strings.TrimSpace(current)
+	if strings.EqualFold(d, c) {
+		return true
+	}
+	if name == "client-output-buffer-limit" {
+		return clientOutputBufferLimitSatisfied(d, c)
+	}
+	if dv, ok := parseValkeyMemory(d); ok {
+		if cv, ok := parseValkeyMemory(c); ok {
+			return dv == cv
+		}
+	}
+	return false
+}
+
+// parseValkeyMemory parses a value in valkey.conf memory notation into bytes.
+// Units per the "Note on units" header of
+// https://github.com/valkey-io/valkey/blob/8.0.5/valkey.conf:
+// 1k => 1000, 1kb => 1024, 1m => 1000*1000, 1mb => 1024*1024,
+// 1g => 1000*1000*1000, 1gb => 1024*1024*1024, case insensitive.
+// Round-trip verified against ghcr.io/halter/valkey-server:8.0.5:
+// CONFIG SET repl-backlog-size 512mb -> CONFIG GET returns "536870912".
+func parseValkeyMemory(s string) (int64, bool) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	mult := int64(1)
+	switch {
+	case strings.HasSuffix(s, "kb"):
+		mult, s = 1024, strings.TrimSuffix(s, "kb")
+	case strings.HasSuffix(s, "mb"):
+		mult, s = 1024*1024, strings.TrimSuffix(s, "mb")
+	case strings.HasSuffix(s, "gb"):
+		mult, s = 1024*1024*1024, strings.TrimSuffix(s, "gb")
+	case strings.HasSuffix(s, "k"):
+		mult, s = 1000, strings.TrimSuffix(s, "k")
+	case strings.HasSuffix(s, "m"):
+		mult, s = 1000*1000, strings.TrimSuffix(s, "m")
+	case strings.HasSuffix(s, "g"):
+		mult, s = 1000*1000*1000, strings.TrimSuffix(s, "g")
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n * mult, true
+}
+
+type clientOutputBufferLimit struct {
+	hard, soft, seconds int64
+}
+
+// parseClientOutputBufferLimitClasses parses "class hard soft seconds"
+// groups. Class names are normalised so "slave" and "replica" compare equal
+// (CONFIG GET reports the class as "slave" for compatibility; config files
+// may use either spelling).
+func parseClientOutputBufferLimitClasses(s string) (map[string]clientOutputBufferLimit, bool) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 || len(fields)%4 != 0 {
+		return nil, false
+	}
+	out := make(map[string]clientOutputBufferLimit, len(fields)/4)
+	for i := 0; i < len(fields); i += 4 {
+		class := strings.ToLower(fields[i])
+		if class == "slave" {
+			class = "replica"
+		}
+		hard, ok := parseValkeyMemory(fields[i+1])
+		if !ok {
+			return nil, false
+		}
+		soft, ok := parseValkeyMemory(fields[i+2])
+		if !ok {
+			return nil, false
+		}
+		seconds, err := strconv.ParseInt(fields[i+3], 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		out[class] = clientOutputBufferLimit{hard: hard, soft: soft, seconds: seconds}
+	}
+	return out, true
+}
+
+// clientOutputBufferLimitSatisfied reports whether every class present in the
+// desired value matches the corresponding class in the current (canonical,
+// all-classes) value. Classes not mentioned in the desired value are left to
+// their current setting, mirroring how a config-file line for one class does
+// not affect the others.
+func clientOutputBufferLimitSatisfied(desired, current string) bool {
+	des, ok := parseClientOutputBufferLimitClasses(desired)
+	if !ok {
+		return false
+	}
+	cur, ok := parseClientOutputBufferLimitClasses(current)
+	if !ok {
+		return false
+	}
+	for class, want := range des {
+		got, present := cur[class]
+		if !present || got != want {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/valkeycluster_controller_config_test.go
+++ b/internal/controller/valkeycluster_controller_config_test.go
@@ -251,6 +251,54 @@ var _ = Describe("managedConfigEntries", func() {
 	})
 })
 
+var _ = Describe("effectiveManagedConfig", func() {
+	It("keeps unique directives in order", func() {
+		entries := []cachev1alpha1.ValkeyConfigParameter{
+			{Name: "maxmemory", Value: "32mb"},
+			{Name: "maxmemory-policy", Value: "allkeys-lru"},
+		}
+		Expect(effectiveManagedConfig(entries)).To(Equal(entries))
+	})
+
+	It("collapses a duplicated directive to the later value at the earlier position", func() {
+		Expect(effectiveManagedConfig([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "repl-backlog-size", Value: "20578304"},
+			{Name: "maxmemory", Value: "32mb"},
+			{Name: "repl-backlog-size", Value: "16mb"},
+		})).To(Equal([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "repl-backlog-size", Value: "16mb"},
+			{Name: "maxmemory", Value: "32mb"},
+		}))
+	})
+
+	It("merges client-output-buffer-limit per class instead of replacing it", func() {
+		Expect(effectiveManagedConfig([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "client-output-buffer-limit", Value: "replica 164626432 82313216 120"},
+			{Name: "client-output-buffer-limit", Value: "pubsub 32mb 8mb 60"},
+		})).To(Equal([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "client-output-buffer-limit", Value: "replica 164626432 82313216 120 pubsub 32mb 8mb 60"},
+		}))
+	})
+
+	It("lets a spec class override the defaulted class, slave spelling included", func() {
+		Expect(effectiveManagedConfig([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "client-output-buffer-limit", Value: "replica 164626432 82313216 120"},
+			{Name: "client-output-buffer-limit", Value: "slave 2gb 1gb 60"},
+		})).To(Equal([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "client-output-buffer-limit", Value: "replica 2gb 1gb 60"},
+		}))
+	})
+
+	It("lets a malformed client-output-buffer-limit override win wholesale", func() {
+		Expect(effectiveManagedConfig([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "client-output-buffer-limit", Value: "replica 164626432 82313216 120"},
+			{Name: "client-output-buffer-limit", Value: "replica 100"},
+		})).To(Equal([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "client-output-buffer-limit", Value: "replica 100"},
+		}))
+	})
+})
+
 var _ = Describe("getValkeyConfigContent with managed defaults", func() {
 	It("renders defaults after the base config and before spec parameters", func() {
 		vc := &cachev1alpha1.ValkeyCluster{

--- a/internal/controller/valkeycluster_controller_config_test.go
+++ b/internal/controller/valkeycluster_controller_config_test.go
@@ -1,0 +1,310 @@
+package controller
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
+)
+
+// Canonical CONFIG GET outputs in these tests were captured from a live
+// ghcr.io/halter/valkey-server:8.0.5 container: memory values come back as
+// plain byte counts, client-output-buffer-limit comes back as the full
+// three-class string using the "slave" spelling.
+var _ = Describe("valkeyConfigValueEqual", func() {
+	It("matches identical strings", func() {
+		Expect(valkeyConfigValueEqual("maxmemory-policy", "allkeys-lru", "allkeys-lru")).To(BeTrue())
+	})
+
+	It("matches case-insensitively", func() {
+		Expect(valkeyConfigValueEqual("dual-channel-replication-enabled", "yes", "YES")).To(BeTrue())
+	})
+
+	It("does not match different booleans", func() {
+		Expect(valkeyConfigValueEqual("dual-channel-replication-enabled", "yes", "no")).To(BeFalse())
+	})
+
+	It("matches a suffixed memory value against its canonical byte count", func() {
+		Expect(valkeyConfigValueEqual("repl-backlog-size", "512mb", "536870912")).To(BeTrue())
+		Expect(valkeyConfigValueEqual("repl-backlog-size", "2gb", "2147483648")).To(BeTrue())
+	})
+
+	It("does not match different memory values", func() {
+		Expect(valkeyConfigValueEqual("repl-backlog-size", "512mb", "536870913")).To(BeFalse())
+		Expect(valkeyConfigValueEqual("repl-backlog-size", "10mb", "536870912")).To(BeFalse())
+	})
+
+	It("matches client-output-buffer-limit for the classes the desired value names", func() {
+		canonical := "normal 0 0 0 slave 2147483648 1073741824 120 pubsub 33554432 8388608 60"
+		Expect(valkeyConfigValueEqual("client-output-buffer-limit",
+			"replica 2147483648 1073741824 120", canonical)).To(BeTrue())
+		Expect(valkeyConfigValueEqual("client-output-buffer-limit",
+			"slave 2gb 1gb 120", canonical)).To(BeTrue())
+		Expect(valkeyConfigValueEqual("client-output-buffer-limit",
+			"normal 0 0 0 pubsub 32mb 8mb 60", canonical)).To(BeTrue())
+	})
+
+	It("does not match client-output-buffer-limit when a named class differs", func() {
+		canonical := "normal 0 0 0 slave 268435456 67108864 60 pubsub 33554432 8388608 60"
+		Expect(valkeyConfigValueEqual("client-output-buffer-limit",
+			"replica 2147483648 1073741824 120", canonical)).To(BeFalse())
+	})
+
+	It("does not match malformed client-output-buffer-limit values", func() {
+		Expect(valkeyConfigValueEqual("client-output-buffer-limit",
+			"replica banana 1073741824 120", "normal 0 0 0 slave 0 0 0 pubsub 0 0 0")).To(BeFalse())
+		Expect(valkeyConfigValueEqual("client-output-buffer-limit",
+			"replica 1 2", "normal 0 0 0 slave 0 0 0 pubsub 0 0 0")).To(BeFalse())
+	})
+
+	It("falls back to inequality for values that are neither identical nor parseable", func() {
+		Expect(valkeyConfigValueEqual("appendfilename", "foo.aof", "bar.aof")).To(BeFalse())
+	})
+})
+
+var _ = Describe("parseValkeyMemory", func() {
+	It("parses valkey.conf unit notation", func() {
+		type row struct {
+			in   string
+			want int64
+		}
+		for _, r := range []row{
+			{"1024", 1024},
+			{"1k", 1000},
+			{"1kb", 1024},
+			{"1m", 1000 * 1000},
+			{"1mb", 1024 * 1024},
+			{"1g", 1000 * 1000 * 1000},
+			{"1gb", 1024 * 1024 * 1024},
+			{"1GB", 1024 * 1024 * 1024},
+			{" 512mb ", 512 * 1024 * 1024},
+		} {
+			got, ok := parseValkeyMemory(r.in)
+			Expect(ok).To(BeTrue(), "input %q", r.in)
+			Expect(got).To(Equal(r.want), "input %q", r.in)
+		}
+	})
+
+	It("rejects non-numeric values", func() {
+		for _, in := range []string{"", "banana", "12x", "mb", "1.5gb"} {
+			_, ok := parseValkeyMemory(in)
+			Expect(ok).To(BeFalse(), "input %q", in)
+		}
+	})
+})
+
+var _ = Describe("imageSupportsManagedDefaults", func() {
+	It("accepts the fleet's valkey >= 8.0 images", func() {
+		for _, img := range []string{
+			"ghcr.io/halter/valkey-server:8.0.5",
+			"ghcr.io/halter/valkey-server:8.1.9",
+			"ghcr.io/halter/valkey-server:9.1.1",
+			"ghcr.io/halter/valkey:8.0.2",
+			"localhost:5000/valkey:8.0.5",
+			"valkey/valkey:v8.0.5",
+		} {
+			Expect(imageSupportsManagedDefaults(img)).To(BeTrue(), "image %q", img)
+		}
+	})
+
+	It("rejects pre-8.0, untagged, digest-pinned, and unparseable images", func() {
+		for _, img := range []string{
+			"ghcr.io/halter/valkey-server:7.2.5",
+			"ghcr.io/halter/valkey-server",
+			"ghcr.io/halter/valkey-server@sha256:deadbeef",
+			"ghcr.io/halter/valkey-server:latest",
+			"localhost:5000/valkey-server",
+			"",
+		} {
+			Expect(imageSupportsManagedDefaults(img)).To(BeFalse(), "image %q", img)
+		}
+	})
+})
+
+var _ = Describe("managedDefaultParameters", func() {
+	cluster := func(image, memory, rawConfig string) *cachev1alpha1.ValkeyCluster {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Image: image,
+			},
+		}
+		if memory != "" {
+			vc.Spec.Resources = &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse(memory),
+				},
+			}
+		}
+		if rawConfig != "" {
+			vc.Spec.ValkeyConfig = &cachev1alpha1.ValkeyConfig{RawConfig: rawConfig}
+		}
+		return vc
+	}
+
+	names := func(params []cachev1alpha1.ValkeyConfigParameter) []string {
+		out := make([]string, 0, len(params))
+		for _, p := range params {
+			out = append(out, p.Name)
+		}
+		return out
+	}
+
+	valueOf := func(params []cachev1alpha1.ValkeyConfigParameter, name string) string {
+		for _, p := range params {
+			if p.Name == name {
+				return p.Value
+			}
+		}
+		return ""
+	}
+
+	It("returns nothing when rawConfig is set (expert mode)", func() {
+		Expect(managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", "16000Mi", "port 6379"))).To(BeEmpty())
+	})
+
+	It("returns nothing for images that do not positively parse as valkey >= 8.0", func() {
+		Expect(managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:7.2.5", "16000Mi", ""))).To(BeEmpty())
+		Expect(managedDefaultParameters(cluster("", "16000Mi", ""))).To(BeEmpty())
+	})
+
+	It("derives the sized directives from the pod memory limit", func() {
+		// 16000Mi mirrors halter-device-service-vk-cluster prod
+		// (terraform/params/prod.tfvars valkey_memory = 16000).
+		params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.1.9", "16000Mi", ""))
+		Expect(names(params)).To(Equal([]string{
+			"dual-channel-replication-enabled",
+			"repl-backlog-size",
+			"client-output-buffer-limit",
+		}))
+		Expect(valueOf(params, "dual-channel-replication-enabled")).To(Equal("yes"))
+		// 16000Mi/16 = 1000Mi, clamped down to the 512MiB max — the SP-1527
+		// incident remediation value.
+		Expect(valueOf(params, "repl-backlog-size")).To(Equal("536870912"))
+		// 16000Mi/2 = 8000Mi, clamped down to the 4GiB max; soft = hard/2.
+		Expect(valueOf(params, "client-output-buffer-limit")).To(Equal("replica 4294967296 2147483648 120"))
+	})
+
+	It("clamps the sized directives up to their minimums on small pods", func() {
+		params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", "128Mi", ""))
+		// 128Mi/16 = 8Mi -> min 10MiB (the compiled default); 128Mi/2 = 64Mi
+		// hits the 64MiB hard-limit floor exactly.
+		Expect(valueOf(params, "repl-backlog-size")).To(Equal("10485760"))
+		Expect(valueOf(params, "client-output-buffer-limit")).To(Equal("replica 67108864 33554432 120"))
+	})
+
+	It("keeps backlog no larger than the replica hard limit across sizes", func() {
+		// A replica hard limit below repl-backlog-size is ignored by valkey
+		// (valkey.conf 8.0.5), so the derivation must never produce that.
+		for _, mem := range []string{"64Mi", "128Mi", "1Gi", "2Gi", "8Gi", "16000Mi", "64Gi"} {
+			params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", mem, ""))
+			backlog, ok := parseValkeyMemory(valueOf(params, "repl-backlog-size"))
+			Expect(ok).To(BeTrue())
+			limits, ok := parseClientOutputBufferLimitClasses(valueOf(params, "client-output-buffer-limit"))
+			Expect(ok).To(BeTrue())
+			Expect(backlog).To(BeNumerically("<=", limits["replica"].hard), "memory %s", mem)
+		}
+	})
+
+	It("emits only dual-channel when there is no memory limit to derive from", func() {
+		params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", "", ""))
+		Expect(names(params)).To(Equal([]string{"dual-channel-replication-enabled"}))
+	})
+})
+
+var _ = Describe("managedConfigEntries", func() {
+	It("orders operator defaults before spec parameters so spec wins", func() {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Image: "ghcr.io/halter/valkey-server:8.0.5",
+				ValkeyConfig: &cachev1alpha1.ValkeyConfig{
+					Parameters: []cachev1alpha1.ValkeyConfigParameter{
+						{Name: "dual-channel-replication-enabled", Value: "no"},
+					},
+				},
+			},
+		}
+		entries := managedConfigEntries(vc)
+		Expect(len(entries)).To(Equal(2))
+		Expect(entries[0]).To(Equal(cachev1alpha1.ValkeyConfigParameter{Name: "dual-channel-replication-enabled", Value: "yes"}))
+		Expect(entries[1]).To(Equal(cachev1alpha1.ValkeyConfigParameter{Name: "dual-channel-replication-enabled", Value: "no"}))
+	})
+
+	It("returns only spec parameters when rawConfig is set", func() {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Image: "ghcr.io/halter/valkey-server:8.0.5",
+				ValkeyConfig: &cachev1alpha1.ValkeyConfig{
+					RawConfig: "port 6379",
+					Parameters: []cachev1alpha1.ValkeyConfigParameter{
+						{Name: "maxmemory", Value: "100mb"},
+					},
+				},
+			},
+		}
+		Expect(managedConfigEntries(vc)).To(Equal([]cachev1alpha1.ValkeyConfigParameter{
+			{Name: "maxmemory", Value: "100mb"},
+		}))
+	})
+})
+
+var _ = Describe("getValkeyConfigContent with managed defaults", func() {
+	It("renders defaults after the base config and before spec parameters", func() {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Image:    "ghcr.io/halter/valkey-server:8.0.5",
+				Password: "hunter2",
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("16000Mi"),
+					},
+				},
+				ValkeyConfig: &cachev1alpha1.ValkeyConfig{
+					Parameters: []cachev1alpha1.ValkeyConfigParameter{
+						{Name: "repl-backlog-size", Value: "1073741824"},
+					},
+				},
+			},
+		}
+		out, err := getValkeyConfigContent(vc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring("cluster-enabled yes"))
+		Expect(out).To(ContainSubstring("requirepass hunter2"))
+		Expect(out).To(ContainSubstring("\ndual-channel-replication-enabled yes"))
+		Expect(out).To(ContainSubstring("\nrepl-backlog-size 536870912"))
+		Expect(out).To(ContainSubstring("\nclient-output-buffer-limit replica 4294967296 2147483648 120"))
+		// The spec parameter is rendered after the default, so it wins under
+		// valkey.conf last-occurrence semantics.
+		defaultIdx := strings.Index(out, "repl-backlog-size 536870912")
+		specIdx := strings.Index(out, "repl-backlog-size 1073741824")
+		Expect(specIdx).To(BeNumerically(">", defaultIdx))
+	})
+
+	It("renders no defaults when rawConfig is set", func() {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Image: "ghcr.io/halter/valkey-server:8.0.5",
+				ValkeyConfig: &cachev1alpha1.ValkeyConfig{
+					RawConfig: "port 6379",
+				},
+			},
+		}
+		out, err := getValkeyConfigContent(vc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("port 6379"))
+	})
+
+	It("renders no defaults for images without positive version support", func() {
+		vc := &cachev1alpha1.ValkeyCluster{
+			Spec: cachev1alpha1.ValkeyClusterSpec{
+				Image: "ghcr.io/halter/valkey-server:7.2.5",
+			},
+		}
+		out, err := getValkeyConfigContent(vc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(ContainSubstring("dual-channel-replication-enabled"))
+	})
+})

--- a/internal/controller/valkeycluster_controller_configmap.go
+++ b/internal/controller/valkeycluster_controller_configmap.go
@@ -123,13 +123,17 @@ func getValkeyConfigContent(valkeyCluster *cachev1alpha1.ValkeyCluster) (string,
 		}
 	}
 
-	if valkeyCluster.Spec.ValkeyConfig == nil || len(valkeyCluster.Spec.ValkeyConfig.Parameters) == 0 {
+	// Operator-managed defaults followed by spec parameters, in the same
+	// order reconcileValkeyConfig live-applies them. Later lines win in
+	// valkey.conf, so spec parameters override the defaults.
+	entries := managedConfigEntries(valkeyCluster)
+	if len(entries) == 0 {
 		return base, nil
 	}
 
 	var sb strings.Builder
 	sb.WriteString(base)
-	for _, p := range valkeyCluster.Spec.ValkeyConfig.Parameters {
+	for _, p := range entries {
 		fmt.Fprintf(&sb, "\n%s %s", p.Name, p.Value)
 	}
 	return sb.String(), nil

--- a/internal/controller/valkeycluster_controller_statefulset.go
+++ b/internal/controller/valkeycluster_controller_statefulset.go
@@ -567,8 +567,6 @@ func (r *ValkeyClusterReconciler) applyDesiredStatefulSetSpec(valkeyCluster *cac
 // automatically; this method drives the rollout. Processing one pod per shard in parallel
 // keeps the rollout fast while maintaining cluster safety.
 func (r *ValkeyClusterReconciler) performRollingUpdate(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster) (*ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
 	stsList := &appsv1.StatefulSetList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(valkeyCluster.Namespace),
@@ -619,44 +617,68 @@ func (r *ValkeyClusterReconciler) performRollingUpdate(ctx context.Context, valk
 			continue
 		}
 
-		// Gate each pod deletion on cluster health. All pods must be Running/Ready
-		// and the cluster must report cluster_state:ok before we proceed.
-		healthy, err := r.isValkeyClusterHealthy(ctx, valkeyCluster)
-		if err != nil {
-			logger.Error(err, "Failed to check Valkey cluster health before rolling update, will retry")
-			return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-		if !healthy {
-			logger.Info("Valkey cluster is not healthy, deferring rolling update",
-				"shard", sts.Name,
-				"podsNeedingUpdate", len(podsNeedingUpdate),
-			)
-			r.Recorder.Event(valkeyCluster, "Warning", "RollingUpdate",
-				fmt.Sprintf("Cluster not healthy, deferring rolling update of shard %s (%d pods pending)", sts.Name, len(podsNeedingUpdate)))
-			return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-
-		// Delete replicas before masters: higher ordinal name = replica, lower = master.
-		sort.Slice(podsNeedingUpdate, func(i, j int) bool {
-			return podsNeedingUpdate[i].Name > podsNeedingUpdate[j].Name
-		})
-		podToDelete := podsNeedingUpdate[0]
-		logger.Info("Deleting pod for rolling update",
-			"pod", podToDelete.Name,
-			"shard", sts.Name,
-			"remainingAfterDeletion", len(podsNeedingUpdate)-1,
-		)
-		if err := r.Delete(ctx, &podToDelete); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete pod for rolling update", "pod", podToDelete.Name)
-			return nil, err
-		}
-		r.Recorder.Event(valkeyCluster, "Normal", "RollingUpdate",
-			fmt.Sprintf("Deleted pod %s for rolling update, %d pods remaining in shard %s", podToDelete.Name, len(podsNeedingUpdate)-1, sts.Name))
-
-		// Return and requeue — we only ever delete one pod per reconcile cycle,
-		// and we complete one shard before advancing to the next.
-		return &ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		// Delete one pod, gated on cluster health — we only ever delete one pod
+		// per reconcile cycle, and we complete one shard before advancing to
+		// the next.
+		return r.deleteOnePodHealthGated(ctx, valkeyCluster, podsNeedingUpdate,
+			"RollingUpdate", "rolling update", fmt.Sprintf(" in shard %s", sts.Name))
 	}
 
 	return nil, nil
+}
+
+// performConfigRestarts deletes pods whose runtime config cannot be converged
+// to spec.valkeyConfig via CONFIG SET (immutable directives, as detected by
+// reconcileValkeyConfig). The recreated pod mounts the current ConfigMap and
+// boots with the desired directive; convergence is re-derived from live state
+// on the next reconcile, so there is no annotation bookkeeping to go stale.
+func (r *ValkeyClusterReconciler) performConfigRestarts(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, pods []corev1.Pod) (*ctrl.Result, error) {
+	if len(pods) == 0 {
+		return nil, nil
+	}
+	return r.deleteOnePodHealthGated(ctx, valkeyCluster, pods, "ConfigRestart", "config restart", "")
+}
+
+// deleteOnePodHealthGated deletes at most one pod per call: the first of the
+// given pods after sorting by name descending, so replicas (higher ordinals)
+// restart before primaries. The deletion is gated on full cluster health —
+// all pods Running/Ready, cluster_state:ok, and replicas caught up — and the
+// caller is requeued to re-derive the remaining work on the next reconcile.
+// scope is an optional suffix for event messages (e.g. " in shard x").
+func (r *ValkeyClusterReconciler) deleteOnePodHealthGated(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, pods []corev1.Pod, eventReason, action, scope string) (*ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	healthy, err := r.isValkeyClusterHealthy(ctx, valkeyCluster)
+	if err != nil {
+		logger.Error(err, "Failed to check Valkey cluster health, will retry", "action", action)
+		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	if !healthy {
+		logger.Info("Valkey cluster is not healthy, deferring pod deletion",
+			"action", action,
+			"podsPending", len(pods),
+		)
+		r.Recorder.Event(valkeyCluster, "Warning", eventReason,
+			fmt.Sprintf("Cluster not healthy, deferring %s%s (%d pods pending)", action, scope, len(pods)))
+		return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	// Delete replicas before primaries: higher ordinal name = replica, lower = primary.
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name > pods[j].Name
+	})
+	podToDelete := pods[0]
+	logger.Info("Deleting pod",
+		"action", action,
+		"pod", podToDelete.Name,
+		"remainingAfterDeletion", len(pods)-1,
+	)
+	if err := r.Delete(ctx, &podToDelete); err != nil && !apierrors.IsNotFound(err) {
+		logger.Error(err, "Failed to delete pod", "action", action, "pod", podToDelete.Name)
+		return nil, err
+	}
+	r.Recorder.Event(valkeyCluster, "Normal", eventReason,
+		fmt.Sprintf("Deleted pod %s for %s, %d pods remaining%s", podToDelete.Name, action, len(pods)-1, scope))
+
+	return &ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 }

--- a/test/e2e/e2e_config_test.go
+++ b/test/e2e/e2e_config_test.go
@@ -1,0 +1,525 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/halter/valkey-cluster-operator/test/utils"
+)
+
+// The declarative-config tests need a cluster whose image tag positively
+// parses as Valkey >= 8.0: the operator-managed replication defaults are
+// version-gated, and the sample cluster used by the "controller" Describe
+// runs the unversioned tag "latest", which deliberately gets no defaults.
+const (
+	configClusterName = "valkeycluster-config"
+	// configClusterMemory is the pod memory limit of the test cluster; the
+	// operator derives its replication-tuning defaults from this value.
+	configClusterMemory      = "314Mi"
+	configClusterMemoryBytes = int64(314) * 1024 * 1024
+	configClusterShards      = 2
+	configClusterReplicas    = 1
+)
+
+var _ = Describe("valkey config", Ordered, func() {
+	BeforeAll(func() {
+		By("creating manager namespace")
+		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		_, _ = utils.Run(cmd)
+
+		By("installing CRDs")
+		cmd = exec.Command("make", "install")
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("deploying the controller-manager")
+		projectimage := "valkey-cluster-operator:latest"
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+		_, err = utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("waiting for controller-manager to be ready")
+		verifyControllerUp := func() error {
+			cmd = exec.Command("kubectl", "get",
+				"pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", namespace,
+			)
+			podOutput, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			podNames := utils.GetNonEmptyLines(string(podOutput))
+			if len(podNames) != 1 {
+				return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
+			}
+			cmd = exec.Command("kubectl", "get",
+				"pods", podNames[0], "-o", "jsonpath={.status.phase}",
+				"-n", namespace,
+			)
+			status, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			if string(status) != "Running" {
+				return fmt.Errorf("controller pod in %s status", status)
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyControllerUp, time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		By("cleaning up config test resources")
+		cmd := exec.Command("kubectl", "delete", "--timeout=30s", "valkeycluster", configClusterName,
+			"-n", namespace,
+		)
+		_, _ = utils.Run(cmd)
+
+		cmd = exec.Command("kubectl", "delete", "--timeout=30s", "pvc",
+			"-l", fmt.Sprintf("cache/name=%s", configClusterName),
+			"-n", namespace,
+		)
+		_, _ = utils.Run(cmd)
+
+		cmd = exec.Command("kubectl", "delete", "--timeout=10s", "deployment", "valkey-cluster-operator-controller-manager",
+			"-n", namespace,
+		)
+		_, _ = utils.Run(cmd)
+	})
+
+	It("should apply operator-managed defaults to a new cluster", func() {
+		By("creating a ValkeyCluster with a versioned >= 8.0 image")
+		cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", "-")
+		cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: cache.halter.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  image: valkey-server:8.0.5
+  shards: %d
+  replicas: %d
+  minReadySeconds: 5
+  resources:
+    limits:
+      cpu: "0.4"
+      memory: %s
+    requests:
+      cpu: "0.2"
+      memory: 214Mi
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+    storageClassName: standard
+  initialDelaySeconds: 5
+`, configClusterName, configClusterShards, configClusterReplicas, configClusterMemory))
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("waiting for the cluster to be ready")
+		EventuallyWithOffset(1, verifyClusterState(configClusterName, configClusterShards, configClusterReplicas, ""), 3*time.Minute, 15*time.Second).Should(Succeed())
+
+		// Expected values mirror the derivation in the README's
+		// "Operator-managed defaults" table for a 314Mi memory limit.
+		backlog, hard, soft := expectedManagedDefaults(configClusterMemoryBytes)
+
+		By("verifying the defaults are rendered into the config file")
+		verifyConfigMap := func() error {
+			return configMapContains(
+				fmt.Sprintf("repl-backlog-size %d", backlog),
+				fmt.Sprintf("client-output-buffer-limit replica %d %d 120", hard, soft),
+				"dual-channel-replication-enabled yes",
+			)
+		}
+		EventuallyWithOffset(1, verifyConfigMap, time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying every pod is running with the defaults")
+		verifyDefaults := func() error {
+			pods, err := configClusterPodNames()
+			if err != nil {
+				return err
+			}
+			for _, pod := range pods {
+				if err := podConfigEquals(pod, "dual-channel-replication-enabled", "yes"); err != nil {
+					return err
+				}
+				if err := podConfigEquals(pod, "repl-backlog-size", strconv.FormatInt(backlog, 10)); err != nil {
+					return err
+				}
+				// CONFIG GET reports the replica class as "slave" inside the
+				// canonical three-class string.
+				value, err := podConfigGet(pod, "client-output-buffer-limit")
+				if err != nil {
+					return err
+				}
+				expected := fmt.Sprintf("slave %d %d 120", hard, soft)
+				if !strings.Contains(value, expected) {
+					return fmt.Errorf("pod %s expected client-output-buffer-limit to contain %q but got %q", pod, expected, value)
+				}
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyDefaults, 2*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should live-apply spec parameters to running pods without restarts", func() {
+		identitiesBefore, err := configClusterPodIdentities()
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("adding runtime-settable parameters to spec.valkeyConfig")
+		patchConfigParameters(`[{"name":"maxmemory","value":"32mb"},{"name":"maxmemory-policy","value":"allkeys-lru"}]`)
+
+		By("verifying every pod converges to the new values")
+		verifyApplied := func() error {
+			pods, err := configClusterPodNames()
+			if err != nil {
+				return err
+			}
+			for _, pod := range pods {
+				// CONFIG GET canonicalises memory values to byte counts.
+				if err := podConfigEquals(pod, "maxmemory", "33554432"); err != nil {
+					return err
+				}
+				if err := podConfigEquals(pod, "maxmemory-policy", "allkeys-lru"); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyApplied, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying no pod was restarted to apply them")
+		identitiesAfter, err := configClusterPodIdentities()
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		ExpectWithOffset(1, identitiesAfter).To(Equal(identitiesBefore))
+	})
+
+	It("should converge manual CONFIG SET drift back to spec", func() {
+		driftedPod := configClusterName + "-0-0"
+
+		By("manually drifting a managed directive on one pod")
+		cmd := exec.Command("kubectl", "-n", namespace, "exec", driftedPod, "-c", "valkey-cluster-node", "--",
+			"valkey-cli", "CONFIG", "SET", "maxmemory-policy", "noeviction")
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		ExpectWithOffset(1, podConfigEquals(driftedPod, "maxmemory-policy", "noeviction")).To(Succeed())
+
+		By("waiting for the operator to converge the directive back to spec")
+		// No spec change accompanies the drift, so nothing is guaranteed to
+		// trigger a watch event; convergence is bounded by the operator's
+		// periodic requeue (5 minutes on a stable cluster). The generous
+		// timeout makes this an honest test of autonomous convergence — the
+		// SP-1527 failure mode was precisely that nothing converged manual
+		// CONFIG SETs back.
+		verifyConverged := func() error {
+			return podConfigEquals(driftedPod, "maxmemory-policy", "allkeys-lru")
+		}
+		EventuallyWithOffset(1, verifyConverged, 7*time.Minute, 15*time.Second).Should(Succeed())
+	})
+
+	It("should let spec parameters override operator-managed defaults", func() {
+		identitiesBefore, err := configClusterPodIdentities()
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("setting repl-backlog-size in spec to override the derived default")
+		patchConfigParameters(`[{"name":"maxmemory","value":"32mb"},{"name":"maxmemory-policy","value":"allkeys-lru"},{"name":"repl-backlog-size","value":"16mb"}]`)
+
+		By("verifying the spec value wins over the default on every pod")
+		verifyOverride := func() error {
+			pods, err := configClusterPodNames()
+			if err != nil {
+				return err
+			}
+			for _, pod := range pods {
+				if err := podConfigEquals(pod, "repl-backlog-size", "16777216"); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyOverride, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying the override is stable, not oscillating with the default")
+		// A directive present in both the operator defaults and the spec must
+		// settle on the spec value: comparing raw entries against a stale
+		// config snapshot would re-apply the default and the override on
+		// alternating reconciles.
+		ConsistentlyWithOffset(1, verifyOverride, 45*time.Second, 5*time.Second).Should(Succeed())
+
+		By("verifying no pod was restarted")
+		identitiesAfter, err := configClusterPodIdentities()
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		ExpectWithOffset(1, identitiesAfter).To(Equal(identitiesBefore))
+	})
+
+	It("should surface rejected values without restarting pods", func() {
+		identitiesBefore, err := configClusterPodIdentities()
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("setting a value the server rejects at runtime")
+		patchConfigParameters(`[{"name":"maxmemory","value":"32mb"},{"name":"maxmemory-policy","value":"bogus-policy"},{"name":"repl-backlog-size","value":"16mb"}]`)
+
+		By("waiting for the ConfigValueRejected warning event")
+		verifyEvent := func() error {
+			return eventWithReasonExists("ConfigValueRejected")
+		}
+		EventuallyWithOffset(1, verifyEvent, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying pods keep running with their last good value instead of restarting")
+		// A restart here would trade a running-but-stale pod for one that
+		// crash-loops on the invalid config file directive.
+		verifyNoRestart := func() error {
+			identities, err := configClusterPodIdentities()
+			if err != nil {
+				return err
+			}
+			for pod, identity := range identitiesBefore {
+				if identities[pod] != identity {
+					return fmt.Errorf("pod %s was restarted (identity %q -> %q)", pod, identity, identities[pod])
+				}
+				if err := podConfigEquals(pod, "maxmemory-policy", "allkeys-lru"); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		ConsistentlyWithOffset(1, verifyNoRestart, 30*time.Second, 5*time.Second).Should(Succeed())
+
+		By("restoring a valid value and verifying the config file is cleaned up")
+		patchConfigParameters(`[{"name":"maxmemory","value":"32mb"},{"name":"maxmemory-policy","value":"allkeys-lru"},{"name":"repl-backlog-size","value":"16mb"}]`)
+		verifyCleanConfigMap := func() error {
+			if err := configMapContains("maxmemory-policy allkeys-lru"); err != nil {
+				return err
+			}
+			cfg, err := configMapValkeyConf()
+			if err != nil {
+				return err
+			}
+			if strings.Contains(cfg, "bogus-policy") {
+				return fmt.Errorf("expected configmap to no longer contain the rejected value, got: %s", cfg)
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyCleanConfigMap, time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	It("should apply immutable directives via a health-gated rolling restart", func() {
+		uidsBefore, err := configClusterPodIdentities()
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("adding an immutable directive to spec.valkeyConfig")
+		// io-threads is IMMUTABLE_CONFIG: CONFIG SET rejects it with "can't
+		// set immutable config", so the only way to apply it is restarting
+		// pods onto the updated config file.
+		patchConfigParameters(`[{"name":"maxmemory","value":"32mb"},{"name":"maxmemory-policy","value":"allkeys-lru"},{"name":"repl-backlog-size","value":"16mb"},{"name":"io-threads","value":"2"}]`)
+
+		// The ConfigRequiresRestart warning event is deliberately not
+		// asserted here: it is re-emitted on every reconcile of a rollout, so
+		// client-go's per-object spam filter (burst of 25, refilling one per
+		// 5 minutes) makes its visibility at any given moment best-effort.
+		// The warning-event surfacing path is covered by the
+		// ConfigValueRejected assertion earlier in this suite; this spec
+		// asserts the restart behaviour itself.
+		By("waiting for every pod to be replaced and running with the directive")
+		expectedPods := configClusterShards + configClusterShards*configClusterReplicas
+		verifyRestarted := func() error {
+			identities, err := configClusterPodIdentities()
+			if err != nil {
+				return err
+			}
+			if len(identities) != expectedPods {
+				return fmt.Errorf("expected %d pods but got %d", expectedPods, len(identities))
+			}
+			for pod, identity := range identities {
+				if uidsBefore[pod] == identity {
+					return fmt.Errorf("pod %s has not been restarted yet", pod)
+				}
+				if err := podConfigEquals(pod, "io-threads", "2"); err != nil {
+					return err
+				}
+			}
+			// The restarts are gated on full cluster health, so the cluster
+			// must come out of the rollout fully converged.
+			return verifyClusterState(configClusterName, configClusterShards, configClusterReplicas, "")()
+		}
+		EventuallyWithOffset(1, verifyRestarted, 10*time.Minute, 15*time.Second).Should(Succeed())
+	})
+})
+
+// expectedManagedDefaults mirrors the derivation in the README's
+// "Operator-managed defaults" table: repl-backlog-size clamp(memory/16,
+// 10MiB, 512MiB) and a replica client-output-buffer-limit of clamp(memory/2,
+// 64MiB, 4GiB) hard / hard/2 soft.
+func expectedManagedDefaults(memoryLimitBytes int64) (backlog, hard, soft int64) {
+	clamp := func(v, lo, hi int64) int64 {
+		return min(max(v, lo), hi)
+	}
+	backlog = clamp(memoryLimitBytes/16, 10*1024*1024, 512*1024*1024)
+	hard = clamp(memoryLimitBytes/2, 64*1024*1024, 4*1024*1024*1024)
+	soft = hard / 2
+	return backlog, hard, soft
+}
+
+// patchConfigParameters sets spec.valkeyConfig.parameters of the config test
+// cluster to the given JSON array.
+func patchConfigParameters(parametersJSON string) {
+	cmd := exec.Command("kubectl",
+		"-n", namespace,
+		"patch", "valkeycluster", configClusterName,
+		"--type=json",
+		fmt.Sprintf(`-p=[{"op":"add","path":"/spec/valkeyConfig","value":{"parameters":%s}}]`, parametersJSON),
+	)
+	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+// configClusterPodNames returns the non-terminating pod names of the config
+// test cluster.
+func configClusterPodNames() ([]string, error) {
+	cmd := exec.Command("kubectl", "get",
+		"pods", "-l", fmt.Sprintf("cache/name=%s", configClusterName),
+		"-o", "go-template={{ range .items }}"+
+			"{{ if not .metadata.deletionTimestamp }}"+
+			"{{ .metadata.name }}"+
+			"{{ \"\\n\" }}{{ end }}{{ end }}",
+		"-n", namespace,
+	)
+	podOutput, err := utils.Run(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("received error getting pods: %w", err)
+	}
+	podNames := utils.GetNonEmptyLines(string(podOutput))
+	expectedPods := configClusterShards + configClusterShards*configClusterReplicas
+	if len(podNames) != expectedPods {
+		return nil, fmt.Errorf("expected %d pods but got %d", expectedPods, len(podNames))
+	}
+	return podNames, nil
+}
+
+// configClusterPodIdentities returns pod name -> "<uid> <restartCounts>" for
+// the config test cluster, capturing both pod replacement (deletion and
+// recreation changes the UID) and in-place container restarts.
+func configClusterPodIdentities() (map[string]string, error) {
+	cmd := exec.Command("kubectl", "get",
+		"pods", "-l", fmt.Sprintf("cache/name=%s", configClusterName),
+		"-o", "go-template={{ range .items }}"+
+			"{{ if not .metadata.deletionTimestamp }}"+
+			"{{ .metadata.name }} {{ .metadata.uid }}"+
+			"{{ range .status.containerStatuses }} {{ .restartCount }}{{ end }}"+
+			"{{ \"\\n\" }}{{ end }}{{ end }}",
+		"-n", namespace,
+	)
+	podOutput, err := utils.Run(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("received error getting pod identities: %w", err)
+	}
+	identities := make(map[string]string)
+	for _, line := range utils.GetNonEmptyLines(string(podOutput)) {
+		name, identity, found := strings.Cut(strings.TrimSpace(line), " ")
+		if !found {
+			return nil, fmt.Errorf("unexpected pod identity line %q", line)
+		}
+		identities[name] = identity
+	}
+	return identities, nil
+}
+
+// podConfigGet returns the live value of a config directive on a pod.
+func podConfigGet(podName, parameter string) (string, error) {
+	cmd := exec.Command("kubectl", "-n", namespace, "exec", podName, "-c", "valkey-cluster-node", "--",
+		"valkey-cli", "CONFIG", "GET", parameter)
+	stdout, _, err := utils.RunWithSplitOutput(cmd)
+	if err != nil {
+		return "", fmt.Errorf("received error running CONFIG GET %s on pod %s: %w", parameter, podName, err)
+	}
+	lines := utils.GetNonEmptyLines(string(stdout))
+	if len(lines) < 2 {
+		return "", fmt.Errorf("expected CONFIG GET %s on pod %s to return a value but got %q", parameter, podName, stdout)
+	}
+	return strings.TrimSpace(lines[1]), nil
+}
+
+func podConfigEquals(podName, parameter, expected string) error {
+	value, err := podConfigGet(podName, parameter)
+	if err != nil {
+		return err
+	}
+	if value != expected {
+		return fmt.Errorf("pod %s expected %s to be %q but got %q", podName, parameter, expected, value)
+	}
+	return nil
+}
+
+// configMapValkeyConf returns the rendered valkey.conf of the config test
+// cluster.
+func configMapValkeyConf() (string, error) {
+	cmd := exec.Command("kubectl", "get", "configmap",
+		configClusterName,
+		"-o", `jsonpath={.data.valkey\.conf}`,
+		"-n", namespace,
+	)
+	cfgOutput, err := utils.Run(cmd)
+	if err != nil {
+		return "", fmt.Errorf("received error getting configmap: %w", err)
+	}
+	return string(cfgOutput), nil
+}
+
+func configMapContains(expected ...string) error {
+	cfg, err := configMapValkeyConf()
+	if err != nil {
+		return err
+	}
+	for _, want := range expected {
+		if !strings.Contains(cfg, want) {
+			return fmt.Errorf("expected configmap to contain %q but got: %s", want, cfg)
+		}
+	}
+	return nil
+}
+
+// eventWithReasonExists reports whether the config test cluster has emitted
+// an event with the given reason.
+func eventWithReasonExists(reason string) error {
+	cmd := exec.Command("kubectl", "get", "events",
+		"-n", namespace,
+		"--field-selector", fmt.Sprintf("reason=%s,involvedObject.name=%s", reason, configClusterName),
+		"-o", "go-template={{ range .items }}{{ .reason }}{{ \"\\n\" }}{{ end }}",
+	)
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return fmt.Errorf("received error getting events: %w", err)
+	}
+	if len(utils.GetNonEmptyLines(string(output))) == 0 {
+		return fmt.Errorf("expected an event with reason %s for %s", reason, configClusterName)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

SP-1527: a `valkeyConfig` change previously reached the ConfigMap and then went nowhere — valkey-server reads its config file once at start, the file is mounted via subPath (running pods never see updates), and the config hash was annotated only on the ConfigMap, explicitly not influencing reconciliation. Incident-response `CONFIG SET`s were likewise silently reverted by any pod restart, with nothing converging them back.

This generalises the `reconcileAuth` pattern into a config reconciler:

- **Live apply + drift convergence**: every reconcile, each directive in `spec.valkeyConfig.parameters` is `CONFIG GET`-compared (semantically: memory values and `client-output-buffer-limit` classes are normalised against the canonical forms `CONFIG GET` returns) and `CONFIG SET` when different. Declarative changes reach running pods without restarts; manual drift converges back to spec. Directives that appear in both the operator defaults and the spec are collapsed to one effective value (last wins; `client-output-buffer-limit` merges per class) before applying, so the live state always matches what a restart onto the rendered config file would produce.

- **Health-gated restart fallback**: directives the server rejects as immutable/protected config are applied by deleting affected pods one per reconcile — replicas before primaries, gated on the same full-health check (including replica catch-up) as the image rolling update, via a shared `deleteOnePodHealthGated` helper. Convergence is re-derived from live state each reconcile, so there is no annotation bookkeeping to go stale.

- **Value rejections do NOT restart**: valkey 8.0.5 refuses to boot on an invalid file directive (verified: exit 1, "Bad directive or wrong number of arguments"), so restarting for a bad value would trade a running-but-stale pod for a crash-looping one. Rejected and unknown directives are surfaced as one aggregated Warning event per directive per reconcile; successful applies are aggregated the same way (one `ConfigUpdated` event per directive per reconcile) so that a rollout touching every pod cannot exhaust client-go's per-object event spam budget and starve the warnings.

- **Fleet defaults** (README "Operator-managed defaults"): for clusters not using `rawConfig` and whose image tag parses as Valkey >= 8.0:
  - `dual-channel-replication-enabled yes`
  - `repl-backlog-size` = clamp(memory/16, 10MiB, 512MiB)
  - `client-output-buffer-limit replica` = clamp(memory/2, 64MiB, 4GiB) /2 120s

  Rendered into the config file between the base and spec parameters and included in the live-apply set, so spec parameters override them in both places. `rawConfig` clusters get no defaults (expert mode); the version gate exists because dual-channel is absent from valkey 7.2's valkey.conf and an unrecognised file directive prevents boot.

## Rollout note

On upgrade, the operator will live-`CONFIG SET` the three defaults onto every pod of every non-rawConfig >=8.0 cluster. All three are runtime-safe: dual-channel affects only subsequent syncs, the buffer limits are ceilings, and the backlog is a bounded allocation.

## Known limitations (documented in README)

- `rawConfig` edits still take effect only as pods restart (the live path manages name/value parameters only).
- Digest-pinned or non-semver image tags get no defaults.

## E2E coverage

A new `valkey config` e2e Describe runs against its own 2-shard/1-replica cluster on `valkey-server:8.0.5` (the sample cluster's `latest` tag deliberately gets no managed defaults) and covers:

1. Operator-managed defaults live on new pods and in the rendered config file, with expected values derived independently from the README clamp formulas.
2. Live apply of spec parameters with **no pod restarts** (pod UID + container restartCount identity).
3. Manual `CONFIG SET` drift converging back to spec with no spec change — bounded only by the periodic requeue, tested honestly with a 7-minute `Eventually` (the incident failure mode).
4. A spec parameter overriding the derived default, and staying overridden (`Consistently`).
5. Runtime-rejected values surfacing a `ConfigValueRejected` warning with **no** restarts.
6. An immutable directive (`io-threads`) applied via the health-gated rolling restart: every pod UID replaced, directive live everywhere, cluster fully converged.

Writing these caught two implementation bugs, fixed in the second commit:

- `ConfigUpdated` was evented per directive **per pod**, exhausting client-go's per-object event spam budget (burst 25, refill 1/5min) and silently starving later events — the `ConfigRequiresRestart` warning was observed dropped while its restarts were executing. Now aggregated per directive per reconcile.
- A directive present in both the defaults and the spec (e.g. overridden `repl-backlog-size`) oscillated between the two values on alternating reconciles, because each raw entry was compared against a config snapshot taken once per pod. Now collapsed to one effective value per directive before applying; unit tests cover the collapse and the per-class `client-output-buffer-limit` merge.

The e2e `go test` timeout rises 30m → 45m (the new Describe adds ~10 minutes, half of it the drift-convergence wait).

## Testing

- Server behaviours cited above were verified against a live `valkey-server:8.0.5` container (immutable-config and value-rejection error strings, memory canonicalisation).
- Unit tests cover the comparators, derivation clamps, version gate, file rendering, and effective-config collapse.
- envtest suite passes locally (`go test ./internal/...`).
- The full `valkey config` e2e Describe passes 6/6 against a kind cluster with the final operator build.

Related: SP-1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)