### PR TITLE
Remediate dead nodes, bound the pre-stop wait, size fleet defaults per pod memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,14 @@ replication-tuning defaults, derived from the pod memory limit:
 | Directive | Default | Rationale |
 |---|---|---|
 | `dual-channel-replication-enabled` | `yes` | Moves full-sync buffering off the primary, structurally avoiding the primary-side output-buffer overrun that kills full syncs of large shards. |
-| `repl-backlog-size` | `clamp(memory/16, 10MiB, 512MiB)` | The compiled-in 10MiB is seconds of backlog on a busy shard; too small a backlog turns every transient disconnect into a full resync. |
-| `client-output-buffer-limit` | `replica clamp(memory/2, 64MiB, 4GiB) <hard/2> 120` | The compiled-in 256MiB hard limit kills full syncs of multi-GiB shards; conversely 256MiB exceeds the whole pod on small caches. |
+| `repl-backlog-size` | `min(clamp(memory/16, 10MiB, 512MiB), hard)` | The compiled-in 10MiB is seconds of backlog on a busy shard; too small a backlog turns every transient disconnect into a full resync. Capped at the replica hard limit, which valkey otherwise ignores. |
+| `client-output-buffer-limit` | `replica min(memory/2, 4GiB) <hard/2> 120` | The compiled-in 256MiB hard limit kills full syncs of multi-GiB shards; conversely 256MiB exceeds the whole pod on small caches, so the limit never exceeds its memory/2 share. |
+
+The sized values respect each pod's memory limit: the config file is sized
+from `spec.resources.limits.memory`, while the live-apply path sizes from the
+pod's actual container limit — after a limit change, existing pods keep their
+old limit until the rolling update replaces them, and buffers sized from the
+new spec could exceed what such a pod really has.
 
 `spec.valkeyConfig.parameters` entries are applied after the defaults, so a
 per-cluster value always overrides the fleet default. The defaults were sized

--- a/internal/controller/scripts/pre_stop.sh
+++ b/internal/controller/scripts/pre_stop.sh
@@ -2,17 +2,27 @@
 
 . /scripts/utils.sh
 
+# the kubelet discards hook output; mirror to the container's stdout
+surface() {
+	msg pre_stop "$1"
+	echo "pre-stop: $1" >/proc/1/fd/1 2>/dev/null || true
+}
+
+# keep the whole hook within the pod's 30s termination grace period
+FAILOVER_WAIT_SECONDS=10
+DRAIN_SLEEP_SECONDS=10
+
 VALKEY_ROLE="$(valkey_cli 127.0.0.1 6379 -c info replication 2>/dev/null | awk '/^role:/ { print $1 }' | tr -d '\r')"
 
 if [ "${VALKEY_ROLE}" != "role:master" ]; then
-	echo "ROLE IS NOT MASTER"
+	surface "skipping failover: role is '${VALKEY_ROLE:-unknown}', not master"
 	exit 0
 fi
 
-CONNTECTED_SLAVES="$(valkey_cli 127.0.0.1 6379 -c info replication | awk -F: '/^connected_slaves:/ { print $2 }')"
+CONNECTED_REPLICAS="$(valkey_cli 127.0.0.1 6379 -c info replication | awk -F: '/^connected_slaves:/ { print $2 }' | tr -d '\r')"
 
-if [ "$CONNTECTED_SLAVES" -le "0" ]; then
-	echo "Connected slaves is 0, therefore nothing to do"
+if [ "${CONNECTED_REPLICAS:-0}" -le "0" ]; then
+	surface "skipping failover: no connected replicas; slots served by this node are unavailable until it restarts"
 	exit 0
 fi
 
@@ -21,14 +31,15 @@ SLAVE_IP="$(echo "${SLAVE0}" | tr , '\n' | awk -F= '/^ip/ { print $2 }')"
 SLAVE_PORT="$(echo "${SLAVE0}" | tr , '\n' | awk -F= '/^port/ { print $2 }')"
 SLAVE_STATUS="$(echo "${SLAVE0}" | tr , '\n' | awk -F= '/^state/ { print $2 }')"
 if [ "${SLAVE_STATUS}" != "online" ]; then
-	echo "Slave status is $SLAVE_STATUS, therefore nothing to do"
+	surface "skipping failover: replica ${SLAVE_IP}:${SLAVE_PORT} state is '${SLAVE_STATUS}', not online"
 	exit 0
 fi
 
-valkey_cli $SLAVE_IP $SLAVE_PORT -c cluster failover
+surface "initiating failover to replica ${SLAVE_IP}:${SLAVE_PORT}"
+valkey_cli "$SLAVE_IP" "$SLAVE_PORT" -c cluster failover
 
 check_failover_complete() {
-	ROLE=$(valkey_cli $SLAVE_IP $SLAVE_PORT INFO REPLICATION | grep role | cut -d':' -f2 | tr -d '\r')
+	ROLE=$(valkey_cli "$SLAVE_IP" "$SLAVE_PORT" INFO REPLICATION | grep role | cut -d':' -f2 | tr -d '\r')
 	if [ "${ROLE}" = "master" ]; then
 		return 0
 	else
@@ -36,10 +47,16 @@ check_failover_complete() {
 	fi
 }
 
-echo "Waiting for failover to complete..."
+WAITED=0
 while ! check_failover_complete; do
+	if [ "$WAITED" -ge "$FAILOVER_WAIT_SECONDS" ]; then
+		surface "failover to ${SLAVE_IP}:${SLAVE_PORT} did not complete within ${FAILOVER_WAIT_SECONDS}s; shutting down anyway"
+		exit 0
+	fi
 	echo "Failover in progress, waiting..."
 	sleep 1
+	WAITED=$((WAITED + 1))
 done
+surface "failover to ${SLAVE_IP}:${SLAVE_PORT} complete; draining for ${DRAIN_SLEEP_SECONDS}s"
 
-sleep 15
+sleep "$DRAIN_SLEEP_SECONDS"

--- a/internal/controller/valkey/utils.go
+++ b/internal/controller/valkey/utils.go
@@ -153,6 +153,34 @@ func FindDeadNodes(topology []*ClusterNode, liveNodeIDs map[string]bool) []*Clus
 	return deadNodes
 }
 
+// UncoveredSlotRanges returns the slots no entry of any view claims.
+func UncoveredSlotRanges(views [][]*ClusterNode) []*ClusterSlotRange {
+	covered := make([]bool, 16384)
+	for _, view := range views {
+		for _, cn := range view {
+			for _, sr := range cn.SlotRanges {
+				for slot := sr.Start; slot <= sr.End && slot < 16384; slot++ {
+					if slot >= 0 {
+						covered[slot] = true
+					}
+				}
+			}
+		}
+	}
+	uncovered := make([]*ClusterSlotRange, 0)
+	for slot := 0; slot < 16384; slot++ {
+		if covered[slot] {
+			continue
+		}
+		if len(uncovered) > 0 && uncovered[len(uncovered)-1].End == slot-1 {
+			uncovered[len(uncovered)-1].End = slot
+			continue
+		}
+		uncovered = append(uncovered, &ClusterSlotRange{Start: slot, End: slot})
+	}
+	return uncovered
+}
+
 func ParseClusterNode(clusterNodesTxt string) (*ClusterNode, error) {
 	for _, line := range strings.Split(clusterNodesTxt, "\n") {
 		if strings.Contains(line, "myself") {

--- a/internal/controller/valkey/utils.go
+++ b/internal/controller/valkey/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,12 +39,11 @@ func (c *ClusterNode) String() string {
 }
 
 func (c *ClusterNode) IsMaster() bool {
-	for _, flag := range c.Flags {
-		if flag == "master" {
-			return true
-		}
-	}
-	return false
+	return c.HasFlag("master")
+}
+
+func (c *ClusterNode) HasFlag(flag string) bool {
+	return slices.Contains(c.Flags, flag)
 }
 func (c *ClusterNode) HasSlots() bool {
 	count := SlotCount(c.SlotRanges)
@@ -126,6 +126,9 @@ func parseClusterNodeLine(line string) (*ClusterNode, error) {
 func ParseClusterNodes(clusterNodesTxt string) ([]*ClusterNode, error) {
 	result := make([]*ClusterNode, 0)
 	for _, line := range strings.Split(clusterNodesTxt, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		clusterNode, err := parseClusterNodeLine(line)
 		if err != nil {
 			return nil, err
@@ -133,6 +136,21 @@ func ParseClusterNodes(clusterNodesTxt string) ([]*ClusterNode, error) {
 		result = append(result, clusterNode)
 	}
 	return result, nil
+}
+
+// FindDeadNodes returns topology entries with the hard "fail" flag (not the
+// unconfirmed "fail?") whose ID is absent from liveNodeIDs.
+func FindDeadNodes(topology []*ClusterNode, liveNodeIDs map[string]bool) []*ClusterNode {
+	deadNodes := make([]*ClusterNode, 0)
+	for _, cn := range topology {
+		if liveNodeIDs[cn.ID] {
+			continue
+		}
+		if cn.HasFlag("fail") {
+			deadNodes = append(deadNodes, cn)
+		}
+	}
+	return deadNodes
 }
 
 func ParseClusterNode(clusterNodesTxt string) (*ClusterNode, error) {

--- a/internal/controller/valkey/utils_test.go
+++ b/internal/controller/valkey/utils_test.go
@@ -663,3 +663,47 @@ fd5a39e1e47b38d0cfabc11388fd7230c2c0f183 10.9.8.19:6379@16379 myself,master - 0 
 		require.Len(t, deadNodes, 2)
 	})
 }
+
+func TestUncoveredSlotRanges(t *testing.T) {
+	view := func(ranges ...ClusterSlotRange) []*ClusterNode {
+		node := &ClusterNode{ID: "a", Flags: []string{"master"}}
+		for i := range ranges {
+			node.SlotRanges = append(node.SlotRanges, &ranges[i])
+		}
+		return []*ClusterNode{node}
+	}
+
+	t.Run("full coverage yields nothing", func(t *testing.T) {
+		got := UncoveredSlotRanges([][]*ClusterNode{view(ClusterSlotRange{0, 16383})})
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns the gap between covered ranges", func(t *testing.T) {
+		got := UncoveredSlotRanges([][]*ClusterNode{view(ClusterSlotRange{0, 5460}, ClusterSlotRange{10922, 16383})})
+		require.Len(t, got, 1)
+		assert.Equal(t, 5461, got[0].Start)
+		assert.Equal(t, 10921, got[0].End)
+	})
+
+	t.Run("unions coverage across views", func(t *testing.T) {
+		got := UncoveredSlotRanges([][]*ClusterNode{
+			view(ClusterSlotRange{0, 5460}),
+			view(ClusterSlotRange{5461, 16383}),
+		})
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns multiple gaps including boundaries", func(t *testing.T) {
+		got := UncoveredSlotRanges([][]*ClusterNode{view(ClusterSlotRange{1, 1}, ClusterSlotRange{3, 16382})})
+		require.Len(t, got, 3)
+		assert.Equal(t, &ClusterSlotRange{0, 0}, got[0])
+		assert.Equal(t, &ClusterSlotRange{2, 2}, got[1])
+		assert.Equal(t, &ClusterSlotRange{16383, 16383}, got[2])
+	})
+
+	t.Run("no views means everything is uncovered", func(t *testing.T) {
+		got := UncoveredSlotRanges(nil)
+		require.Len(t, got, 1)
+		assert.Equal(t, &ClusterSlotRange{0, 16383}, got[0])
+	})
+}

--- a/internal/controller/valkey/utils_test.go
+++ b/internal/controller/valkey/utils_test.go
@@ -617,3 +617,49 @@ slave_repl_offset:999
 		})
 	}
 }
+
+func TestFindDeadNodes(t *testing.T) {
+	topologyTxt := `530e79a7306c62ce8edd1d1fd23ceb42f0b76529 10.9.0.118:6379@16379 master - 0 1747631314884 1 connected 8192-16383
+fd5a39e1e47b38d0cfabc11388fd7230c2c0f183 10.9.8.19:6379@16379 myself,master - 0 0 0 connected
+2ce359297f259ff422218053d9c38e8eee5ac3f6 10.9.15.190:6379@16379 master,fail - 1747631310000 1747631314000 2 connected 0-8191
+552b84fa4644cdb3dd963462378dc3805568c2ae 10.9.22.221:6379@16379 slave,fail 2ce359297f259ff422218053d9c38e8eee5ac3f6 1747631310000 1747631315388 2 connected
+64c28a06b360d40fc811eee290fd874fe08a140e 10.9.22.17:6379@16379 master,fail? - 0 1747631315000 7 connected
+`
+
+	topology, err := ParseClusterNodes(topologyTxt)
+	require.NoError(t, err)
+	require.Len(t, topology, 5)
+
+	t.Run("returns hard-failed nodes not backed by a live pod", func(t *testing.T) {
+		liveNodeIDs := map[string]bool{
+			"530e79a7306c62ce8edd1d1fd23ceb42f0b76529": true,
+			"fd5a39e1e47b38d0cfabc11388fd7230c2c0f183": true,
+		}
+		deadNodes := FindDeadNodes(topology, liveNodeIDs)
+		require.Len(t, deadNodes, 2)
+		assert.Equal(t, "2ce359297f259ff422218053d9c38e8eee5ac3f6", deadNodes[0].ID)
+		assert.True(t, deadNodes[0].HasSlots())
+		assert.Equal(t, 8192, deadNodes[0].SlotCount())
+		assert.Equal(t, "552b84fa4644cdb3dd963462378dc3805568c2ae", deadNodes[1].ID)
+		assert.False(t, deadNodes[1].HasSlots())
+	})
+
+	t.Run("does not report a fail-flagged node that a live pod answers for", func(t *testing.T) {
+		liveNodeIDs := map[string]bool{
+			"530e79a7306c62ce8edd1d1fd23ceb42f0b76529": true,
+			"fd5a39e1e47b38d0cfabc11388fd7230c2c0f183": true,
+			"2ce359297f259ff422218053d9c38e8eee5ac3f6": true,
+			"552b84fa4644cdb3dd963462378dc3805568c2ae": true,
+		}
+		deadNodes := FindDeadNodes(topology, liveNodeIDs)
+		assert.Empty(t, deadNodes)
+	})
+
+	t.Run("does not report unconfirmed fail? or healthy absent nodes", func(t *testing.T) {
+		deadNodes := FindDeadNodes(topology, map[string]bool{})
+		for _, dead := range deadNodes {
+			assert.True(t, dead.HasFlag("fail"), "node %s", dead.ID)
+		}
+		require.Len(t, deadNodes, 2)
+	})
+}

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -410,6 +410,17 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("Could not build cluster nodes: %w", err)
 	}
 
+	// Must run before slot assignment and replication setup, which both fight
+	// a dead node's slot ownership.
+	res, err = r.remediateDeadNodes(ctx, valkeyCluster, clusterNodes)
+	if err != nil {
+		log.Error(err, "Failed to remediate dead cluster nodes")
+		return ctrl.Result{}, err
+	}
+	if res != nil {
+		return *res, nil
+	}
+
 	// cluster meet
 	for _, clusterNodeA := range clusterNodes {
 		for _, clusterNodeB := range clusterNodes {

--- a/internal/controller/valkeycluster_controller_config.go
+++ b/internal/controller/valkeycluster_controller_config.go
@@ -20,33 +20,20 @@ const (
 	// managedDefaultReplBacklogMin is Valkey's compiled-in default (10mb).
 	managedDefaultReplBacklogMin = int64(10 * 1024 * 1024)
 	managedDefaultReplBacklogMax = int64(512 * 1024 * 1024)
-	managedDefaultReplicaHardMin = int64(64 * 1024 * 1024)
 	managedDefaultReplicaHardMax = int64(4 * 1024 * 1024 * 1024)
 	// managedDefaultReplicaSoftSeconds is the soft-limit window (compiled
 	// default is 60s).
 	managedDefaultReplicaSoftSeconds = 120
 )
 
-// managedDefaultParameters returns the operator-wide replication-tuning
-// defaults, derived from the cluster's pod memory limit. Sizing rationale:
-// README, "Operator-managed defaults". They are returned only when:
-//
-//   - spec.valkeyConfig.rawConfig is empty. A raw config replaces the
-//     operator's default config file wholesale — expert mode — so the
-//     operator does not layer defaults it cannot see overridden.
-//   - the image tag parses as Valkey >= 8.0, the version that introduced
-//     dual-channel-replication-enabled (absent from valkey 7.2's valkey.conf,
-//     documented in 8.0.5's). Rendering a directive an older server does not
-//     recognise into the config file would stop pods from booting (verified
-//     on ghcr.io/halter/valkey-server:8.0.5: an unknown file directive exits
-//     1 with "Bad directive or wrong number of arguments"). Unparseable tags
-//     (digest pins, non-numeric tags) get no defaults — the safe direction:
-//     behaviour is unchanged from operator versions before this.
-//
-// spec.valkeyConfig.parameters entries are appended after these (both in the
-// config file and in the live-apply order), so a per-cluster value always
-// overrides the fleet default.
 func managedDefaultParameters(valkeyCluster *cachev1alpha1.ValkeyCluster) []cachev1alpha1.ValkeyConfigParameter {
+	return managedDefaultParametersForMemory(valkeyCluster, specMemoryLimitBytes(valkeyCluster))
+}
+
+// Only without rawConfig and on images parsing as valkey >= 8.0 — older
+// servers refuse to boot on unknown file directives. Sized values keep
+// hard <= memory/2 and backlog <= hard.
+func managedDefaultParametersForMemory(valkeyCluster *cachev1alpha1.ValkeyCluster, memoryLimit int64) []cachev1alpha1.ValkeyConfigParameter {
 	if valkeyCluster.Spec.ValkeyConfig != nil && valkeyCluster.Spec.ValkeyConfig.RawConfig != "" {
 		return nil
 	}
@@ -58,20 +45,13 @@ func managedDefaultParameters(valkeyCluster *cachev1alpha1.ValkeyCluster) []cach
 		{Name: "dual-channel-replication-enabled", Value: "yes"},
 	}
 
-	memoryLimit := podMemoryLimitBytes(valkeyCluster)
 	if memoryLimit <= 0 {
-		// No sizing basis — leave the sized directives at compiled defaults.
 		return defaults
 	}
 
-	backlog := min(max(memoryLimit/16, managedDefaultReplBacklogMin), managedDefaultReplBacklogMax)
-
-	// The replica hard limit must stay above repl-backlog-size (a replica
-	// limit below it is ignored, per valkey.conf 8.0.5); with memory/16 vs
-	// memory/2 and these clamp ranges, backlog <= hard holds for every
-	// memory value.
-	hard := min(max(memoryLimit/2, managedDefaultReplicaHardMin), managedDefaultReplicaHardMax)
+	hard := min(memoryLimit/2, managedDefaultReplicaHardMax)
 	soft := hard / 2
+	backlog := min(max(memoryLimit/16, managedDefaultReplBacklogMin), managedDefaultReplBacklogMax, hard)
 
 	return append(defaults,
 		cachev1alpha1.ValkeyConfigParameter{Name: "repl-backlog-size", Value: strconv.FormatInt(backlog, 10)},
@@ -105,11 +85,23 @@ func imageSupportsManagedDefaults(image string) bool {
 	return major >= 8
 }
 
-func podMemoryLimitBytes(valkeyCluster *cachev1alpha1.ValkeyCluster) int64 {
+func specMemoryLimitBytes(valkeyCluster *cachev1alpha1.ValkeyCluster) int64 {
 	if valkeyCluster.Spec.Resources == nil {
 		return 0
 	}
 	return valkeyCluster.Spec.Resources.Limits.Memory().Value()
+}
+
+func podMemoryLimitBytes(valkeyCluster *cachev1alpha1.ValkeyCluster, pod *corev1.Pod) int64 {
+	for _, container := range pod.Spec.Containers {
+		if container.Name != "valkey-cluster-node" {
+			continue
+		}
+		if v := container.Resources.Limits.Memory().Value(); v > 0 {
+			return v
+		}
+	}
+	return specMemoryLimitBytes(valkeyCluster)
 }
 
 // managedConfigEntries returns the ordered list of config directives the
@@ -123,7 +115,18 @@ func podMemoryLimitBytes(valkeyCluster *cachev1alpha1.ValkeyCluster) int64 {
 // reconcileValkeyConfig live-applies their effectiveManagedConfig collapse,
 // keeping the live-applied state and the restart state identical.
 func managedConfigEntries(valkeyCluster *cachev1alpha1.ValkeyCluster) []cachev1alpha1.ValkeyConfigParameter {
-	entries := managedDefaultParameters(valkeyCluster)
+	return appendSpecParameters(valkeyCluster, managedDefaultParameters(valkeyCluster))
+}
+
+// managedConfigEntriesForPod sizes the defaults from the pod's actual
+// container memory limit, which can lag spec.resources until the pod is
+// replaced by the rolling update.
+func managedConfigEntriesForPod(valkeyCluster *cachev1alpha1.ValkeyCluster, pod *corev1.Pod) []cachev1alpha1.ValkeyConfigParameter {
+	return appendSpecParameters(valkeyCluster,
+		managedDefaultParametersForMemory(valkeyCluster, podMemoryLimitBytes(valkeyCluster, pod)))
+}
+
+func appendSpecParameters(valkeyCluster *cachev1alpha1.ValkeyCluster, entries []cachev1alpha1.ValkeyConfigParameter) []cachev1alpha1.ValkeyConfigParameter {
 	if valkeyCluster.Spec.ValkeyConfig != nil {
 		entries = append(entries, valkeyCluster.Spec.ValkeyConfig.Parameters...)
 	}
@@ -212,14 +215,8 @@ func mergeClientOutputBufferLimit(base, override string) string {
 func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster) ([]corev1.Pod, error) {
 	logger := log.FromContext(ctx)
 
-	entries := effectiveManagedConfig(managedConfigEntries(valkeyCluster))
-	if len(entries) == 0 {
+	if len(effectiveManagedConfig(managedConfigEntries(valkeyCluster))) == 0 {
 		return nil, nil
-	}
-
-	names := make([]string, 0, len(entries))
-	for _, e := range entries {
-		names = append(names, e.Name)
 	}
 
 	podList := &corev1.PodList{}
@@ -246,6 +243,14 @@ func (r *ValkeyClusterReconciler) reconcileValkeyConfig(ctx context.Context, val
 	for _, pod := range podList.Items {
 		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
 			continue
+		}
+		entries := effectiveManagedConfig(managedConfigEntriesForPod(valkeyCluster, &pod))
+		if len(entries) == 0 {
+			continue
+		}
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name)
 		}
 		valkeyClient, err := r.NewValkeyClient(ctx, valkeyCluster, pod.Status.PodIP, VALKEY_PORT)
 		if err != nil {

--- a/internal/controller/valkeycluster_controller_config_test.go
+++ b/internal/controller/valkeycluster_controller_config_test.go
@@ -188,12 +188,16 @@ var _ = Describe("managedDefaultParameters", func() {
 		Expect(valueOf(params, "client-output-buffer-limit")).To(Equal("replica 4294967296 2147483648 120"))
 	})
 
-	It("clamps the sized directives up to their minimums on small pods", func() {
+	It("clamps the backlog up to its minimum on small pods", func() {
 		params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", "128Mi", ""))
-		// 128Mi/16 = 8Mi -> min 10MiB (the compiled default); 128Mi/2 = 64Mi
-		// hits the 64MiB hard-limit floor exactly.
 		Expect(valueOf(params, "repl-backlog-size")).To(Equal("10485760"))
 		Expect(valueOf(params, "client-output-buffer-limit")).To(Equal("replica 67108864 33554432 120"))
+	})
+
+	It("keeps the sized directives within the pod's memory share on tiny pods", func() {
+		params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", "64Mi", ""))
+		Expect(valueOf(params, "client-output-buffer-limit")).To(Equal("replica 33554432 16777216 120"))
+		Expect(valueOf(params, "repl-backlog-size")).To(Equal("10485760"))
 	})
 
 	It("keeps backlog no larger than the replica hard limit across sizes", func() {
@@ -212,6 +216,50 @@ var _ = Describe("managedDefaultParameters", func() {
 	It("emits only dual-channel when there is no memory limit to derive from", func() {
 		params := managedDefaultParameters(cluster("ghcr.io/halter/valkey-server:8.0.5", "", ""))
 		Expect(names(params)).To(Equal([]string{"dual-channel-replication-enabled"}))
+	})
+
+	Describe("per-pod sizing for the live-apply path", func() {
+		pod := func(memory string) *corev1.Pod {
+			p := &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "valkey-exporter"},
+						{Name: "valkey-cluster-node"},
+					},
+				},
+			}
+			if memory != "" {
+				p.Spec.Containers[1].Resources.Limits = corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse(memory),
+				}
+			}
+			return p
+		}
+
+		It("sizes from the pod's actual container limit, not the spec", func() {
+			vc := cluster("ghcr.io/halter/valkey-server:8.0.5", "16000Mi", "")
+			entries := managedConfigEntriesForPod(vc, pod("1Gi"))
+			Expect(valueOf(entries, "repl-backlog-size")).To(Equal("67108864"))
+			Expect(valueOf(entries, "client-output-buffer-limit")).To(Equal("replica 536870912 268435456 120"))
+		})
+
+		It("falls back to the spec limit when the pod carries none", func() {
+			vc := cluster("ghcr.io/halter/valkey-server:8.0.5", "16000Mi", "")
+			entries := managedConfigEntriesForPod(vc, pod(""))
+			Expect(valueOf(entries, "repl-backlog-size")).To(Equal("536870912"))
+			Expect(valueOf(entries, "client-output-buffer-limit")).To(Equal("replica 4294967296 2147483648 120"))
+		})
+
+		It("appends spec parameters after the pod-sized defaults so spec wins", func() {
+			vc := cluster("ghcr.io/halter/valkey-server:8.0.5", "16000Mi", "")
+			vc.Spec.ValkeyConfig = &cachev1alpha1.ValkeyConfig{
+				Parameters: []cachev1alpha1.ValkeyConfigParameter{
+					{Name: "repl-backlog-size", Value: "16mb"},
+				},
+			}
+			entries := effectiveManagedConfig(managedConfigEntriesForPod(vc, pod("1Gi")))
+			Expect(valueOf(entries, "repl-backlog-size")).To(Equal("16mb"))
+		})
 	})
 })
 

--- a/internal/controller/valkeycluster_controller_deadnodes.go
+++ b/internal/controller/valkeycluster_controller_deadnodes.go
@@ -1,0 +1,150 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	cachev1alpha1 "github.com/halter/valkey-cluster-operator/api/v1alpha1"
+	internalValkey "github.com/halter/valkey-cluster-operator/internal/controller/valkey"
+)
+
+// remediateDeadNodes recovers from fail-flagged cluster nodes that no pod
+// backs anymore: promote a surviving replica, otherwise cover the orphaned
+// slots via cluster fix, then CLUSTER FORGET the dead ID on every live node.
+func (r *ValkeyClusterReconciler) remediateDeadNodes(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, clusterNodes []*internalValkey.ClusterNode) (*ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if len(clusterNodes) == 0 {
+		return nil, nil
+	}
+
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(valkeyCluster.Namespace),
+		client.MatchingLabels(labelsForValkeyCluster(valkeyCluster.Name)),
+	}
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return nil, err
+	}
+	representedPods := make(map[string]bool, len(clusterNodes))
+	liveNodeIDs := make(map[string]bool, len(clusterNodes))
+	for _, cn := range clusterNodes {
+		representedPods[cn.Pod] = true
+		liveNodeIDs[cn.ID] = true
+	}
+	for _, pod := range podList.Items {
+		// A restarting pod keeps its node ID via its PVC — only act once
+		// every pod is accounted for.
+		if pod.DeletionTimestamp != nil || !representedPods[pod.Name] {
+			logger.Info("Skipping dead-node detection: pod not represented in cluster nodes",
+				"pod", pod.Name)
+			return nil, nil
+		}
+	}
+
+	valkeyClient, err := r.NewValkeyClient(ctx, valkeyCluster, clusterNodes[0].IP, VALKEY_PORT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create valkey client for dead-node detection: %w", err)
+	}
+	defer valkeyClient.Close()
+	topologyTxt, err := valkeyClient.Do(ctx, valkeyClient.B().ClusterNodes().Build()).ToString()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster topology for dead-node detection: %w", err)
+	}
+	topology, err := internalValkey.ParseClusterNodes(topologyTxt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cluster topology for dead-node detection: %w", err)
+	}
+
+	deadNodes := internalValkey.FindDeadNodes(topology, liveNodeIDs)
+	if len(deadNodes) == 0 {
+		return nil, nil
+	}
+
+	for _, dead := range deadNodes {
+		logger.Info("Detected dead cluster node with no backing pod",
+			"nodeID", dead.ID,
+			"slotCount", dead.SlotCount(),
+			"flags", dead.Flags)
+	}
+
+	for _, dead := range deadNodes {
+		if !dead.HasSlots() {
+			continue
+		}
+		for _, cn := range clusterNodes {
+			if cn.MasterNodeID != dead.ID {
+				continue
+			}
+			logger.Info("Promoting surviving replica of dead node via CLUSTER FAILOVER TAKEOVER",
+				"replicaPod", cn.Pod,
+				"replicaID", cn.ID,
+				"deadNodeID", dead.ID)
+			replicaClient, err := r.NewValkeyClient(ctx, valkeyCluster, cn.IP, VALKEY_PORT)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create valkey client for replica takeover on pod %s: %w", cn.Pod, err)
+			}
+			defer replicaClient.Close()
+			if err := replicaClient.Do(ctx, replicaClient.B().ClusterFailover().Takeover().Build()).Error(); err != nil {
+				return nil, fmt.Errorf("failed to promote replica %s over dead node %s: %w", cn.Pod, dead.ID, err)
+			}
+			r.Recorder.Event(valkeyCluster, "Warning", "DeadNodeTakeover",
+				fmt.Sprintf("Node %s owns %d slots but has no backing pod; promoted surviving replica %s via CLUSTER FAILOVER TAKEOVER", dead.ID, dead.SlotCount(), cn.Pod))
+			return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+	}
+
+	needsSlotTakeover := false
+	for _, dead := range deadNodes {
+		if dead.HasSlots() {
+			needsSlotTakeover = true
+		}
+	}
+	if needsSlotTakeover {
+		jobMgr := r.NewValkeyJobManager()
+		if err := jobMgr.FixClusterSlots(ctx, valkeyCluster, logger); err != nil {
+			if errors.Is(err, errValkeyCliJobStillRunning) {
+				logger.Info("valkey-cli Job still running, requeueing before dead-node slot takeover",
+					"requeueAfter", "30s")
+				return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+			return nil, fmt.Errorf("failed to take over slots of dead nodes: %w", err)
+		}
+		r.Recorder.Event(valkeyCluster, "Warning", "DeadNodeSlotTakeover",
+			fmt.Sprintf("Reassigned slots owned by %d dead node(s) with no surviving replica to reachable primaries", len(deadNodes)))
+	}
+
+	for _, dead := range deadNodes {
+		forgotten := 0
+		for _, cn := range clusterNodes {
+			nodeClient, err := r.NewValkeyClient(ctx, valkeyCluster, cn.IP, VALKEY_PORT)
+			if err != nil {
+				logger.Info("Could not create valkey client to forget dead node, will retry next reconcile",
+					"pod", cn.Pod, "deadNodeID", dead.ID, "error", err.Error())
+				continue
+			}
+			defer nodeClient.Close()
+			if err := nodeClient.Do(ctx, nodeClient.B().ClusterForget().NodeId(dead.ID).Build()).Error(); err != nil {
+				logger.Info("CLUSTER FORGET rejected, will retry next reconcile",
+					"pod", cn.Pod, "deadNodeID", dead.ID, "error", err.Error())
+				continue
+			}
+			forgotten++
+		}
+		logger.Info("Forgot dead cluster node",
+			"deadNodeID", dead.ID,
+			"forgottenOn", forgotten,
+			"liveNodes", len(clusterNodes))
+		r.Recorder.Event(valkeyCluster, "Normal", "DeadNodeForgotten",
+			fmt.Sprintf("Removed dead node %s (no backing pod) from %d of %d live nodes via CLUSTER FORGET", dead.ID, forgotten, len(clusterNodes)))
+	}
+
+	return &ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+}

--- a/internal/controller/valkeycluster_controller_deadnodes.go
+++ b/internal/controller/valkeycluster_controller_deadnodes.go
@@ -2,8 +2,8 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -16,8 +16,11 @@ import (
 )
 
 // remediateDeadNodes recovers from fail-flagged cluster nodes that no pod
-// backs anymore: promote a surviving replica, otherwise cover the orphaned
-// slots via cluster fix, then CLUSTER FORGET the dead ID on every live node.
+// backs anymore, one idempotent step per reconcile so any partial state
+// converges: promote a surviving replica of a dead node, CLUSTER FORGET the
+// dead ID on every live node, then cover slots left assigned to nobody via
+// CLUSTER ADDSLOTSRANGE on a live primary. valkey-cli's fix is unusable
+// here: it prompts for slot coverage even under --cluster-yes.
 func (r *ValkeyClusterReconciler) remediateDeadNodes(ctx context.Context, valkeyCluster *cachev1alpha1.ValkeyCluster, clusterNodes []*internalValkey.ClusterNode) (*ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -49,102 +52,129 @@ func (r *ValkeyClusterReconciler) remediateDeadNodes(ctx context.Context, valkey
 		}
 	}
 
-	valkeyClient, err := r.NewValkeyClient(ctx, valkeyCluster, clusterNodes[0].IP, VALKEY_PORT)
+	// A running valkey-cli Job (e.g. a reshard) may be moving slots; acting
+	// on a topology snapshot taken mid-migration could misread coverage.
+	runningJob, err := r.settleValkeyCliJobs(ctx, valkeyCluster, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create valkey client for dead-node detection: %w", err)
+		return nil, err
 	}
-	defer valkeyClient.Close()
-	topologyTxt, err := valkeyClient.Do(ctx, valkeyClient.B().ClusterNodes().Build()).ToString()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cluster topology for dead-node detection: %w", err)
-	}
-	topology, err := internalValkey.ParseClusterNodes(topologyTxt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cluster topology for dead-node detection: %w", err)
-	}
-
-	deadNodes := internalValkey.FindDeadNodes(topology, liveNodeIDs)
-	if len(deadNodes) == 0 {
+	if runningJob != nil {
 		return nil, nil
 	}
 
-	for _, dead := range deadNodes {
-		logger.Info("Detected dead cluster node with no backing pod",
-			"nodeID", dead.ID,
-			"slotCount", dead.SlotCount(),
-			"flags", dead.Flags)
+	views := make([][]*internalValkey.ClusterNode, 0, len(clusterNodes))
+	deadNodes := make(map[string]*internalValkey.ClusterNode)
+	for _, cn := range clusterNodes {
+		valkeyClient, err := r.NewValkeyClient(ctx, valkeyCluster, cn.IP, VALKEY_PORT)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create valkey client for dead-node detection on pod %s: %w", cn.Pod, err)
+		}
+		defer valkeyClient.Close()
+		topologyTxt, err := valkeyClient.Do(ctx, valkeyClient.B().ClusterNodes().Build()).ToString()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cluster topology from pod %s: %w", cn.Pod, err)
+		}
+		view, err := internalValkey.ParseClusterNodes(topologyTxt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cluster topology from pod %s: %w", cn.Pod, err)
+		}
+		views = append(views, view)
+		for _, dead := range internalValkey.FindDeadNodes(view, liveNodeIDs) {
+			if existing, ok := deadNodes[dead.ID]; !ok || (!existing.HasSlots() && dead.HasSlots()) {
+				deadNodes[dead.ID] = dead
+			}
+		}
 	}
 
-	for _, dead := range deadNodes {
-		if !dead.HasSlots() {
-			continue
-		}
+	// Promote a surviving replica of a dead node first: its data survives,
+	// and no live node may still replicate a dead ID when FORGET runs.
+	for deadID, dead := range deadNodes {
 		for _, cn := range clusterNodes {
-			if cn.MasterNodeID != dead.ID {
+			if cn.MasterNodeID != deadID {
 				continue
 			}
 			logger.Info("Promoting surviving replica of dead node via CLUSTER FAILOVER TAKEOVER",
 				"replicaPod", cn.Pod,
 				"replicaID", cn.ID,
-				"deadNodeID", dead.ID)
+				"deadNodeID", deadID)
 			replicaClient, err := r.NewValkeyClient(ctx, valkeyCluster, cn.IP, VALKEY_PORT)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create valkey client for replica takeover on pod %s: %w", cn.Pod, err)
 			}
 			defer replicaClient.Close()
 			if err := replicaClient.Do(ctx, replicaClient.B().ClusterFailover().Takeover().Build()).Error(); err != nil {
-				return nil, fmt.Errorf("failed to promote replica %s over dead node %s: %w", cn.Pod, dead.ID, err)
+				return nil, fmt.Errorf("failed to promote replica %s over dead node %s: %w", cn.Pod, deadID, err)
 			}
 			r.Recorder.Event(valkeyCluster, "Warning", "DeadNodeTakeover",
-				fmt.Sprintf("Node %s owns %d slots but has no backing pod; promoted surviving replica %s via CLUSTER FAILOVER TAKEOVER", dead.ID, dead.SlotCount(), cn.Pod))
+				fmt.Sprintf("Node %s owns %d slots but has no backing pod; promoted surviving replica %s via CLUSTER FAILOVER TAKEOVER", deadID, dead.SlotCount(), cn.Pod))
 			return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 	}
 
-	needsSlotTakeover := false
-	for _, dead := range deadNodes {
-		if dead.HasSlots() {
-			needsSlotTakeover = true
-		}
-	}
-	if needsSlotTakeover {
-		jobMgr := r.NewValkeyJobManager()
-		if err := jobMgr.FixClusterSlots(ctx, valkeyCluster, logger); err != nil {
-			if errors.Is(err, errValkeyCliJobStillRunning) {
-				logger.Info("valkey-cli Job still running, requeueing before dead-node slot takeover",
-					"requeueAfter", "30s")
-				return &ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	if len(deadNodes) > 0 {
+		for deadID := range deadNodes {
+			logger.Info("Detected dead cluster node with no backing pod",
+				"nodeID", deadID,
+				"slotCount", deadNodes[deadID].SlotCount(),
+				"flags", deadNodes[deadID].Flags)
+			forgotten := 0
+			for _, cn := range clusterNodes {
+				nodeClient, err := r.NewValkeyClient(ctx, valkeyCluster, cn.IP, VALKEY_PORT)
+				if err != nil {
+					logger.Info("Could not create valkey client to forget dead node, will retry next reconcile",
+						"pod", cn.Pod, "deadNodeID", deadID, "error", err.Error())
+					continue
+				}
+				defer nodeClient.Close()
+				err = nodeClient.Do(ctx, nodeClient.B().ClusterForget().NodeId(deadID).Build()).Error()
+				if err != nil && !strings.Contains(err.Error(), "Unknown node") {
+					logger.Info("CLUSTER FORGET rejected, will retry next reconcile",
+						"pod", cn.Pod, "deadNodeID", deadID, "error", err.Error())
+					continue
+				}
+				forgotten++
 			}
-			return nil, fmt.Errorf("failed to take over slots of dead nodes: %w", err)
+			r.Recorder.Event(valkeyCluster, "Normal", "DeadNodeForgotten",
+				fmt.Sprintf("Removed dead node %s (no backing pod) from %d of %d live nodes via CLUSTER FORGET", deadID, forgotten, len(clusterNodes)))
 		}
-		r.Recorder.Event(valkeyCluster, "Warning", "DeadNodeSlotTakeover",
-			fmt.Sprintf("Reassigned slots owned by %d dead node(s) with no surviving replica to reachable primaries", len(deadNodes)))
-	}
-
-	for _, dead := range deadNodes {
-		forgotten := 0
-		for _, cn := range clusterNodes {
-			nodeClient, err := r.NewValkeyClient(ctx, valkeyCluster, cn.IP, VALKEY_PORT)
-			if err != nil {
-				logger.Info("Could not create valkey client to forget dead node, will retry next reconcile",
-					"pod", cn.Pod, "deadNodeID", dead.ID, "error", err.Error())
-				continue
-			}
-			defer nodeClient.Close()
-			if err := nodeClient.Do(ctx, nodeClient.B().ClusterForget().NodeId(dead.ID).Build()).Error(); err != nil {
-				logger.Info("CLUSTER FORGET rejected, will retry next reconcile",
-					"pod", cn.Pod, "deadNodeID", dead.ID, "error", err.Error())
-				continue
-			}
-			forgotten++
-		}
-		logger.Info("Forgot dead cluster node",
-			"deadNodeID", dead.ID,
-			"forgottenOn", forgotten,
-			"liveNodes", len(clusterNodes))
-		r.Recorder.Event(valkeyCluster, "Normal", "DeadNodeForgotten",
-			fmt.Sprintf("Removed dead node %s (no backing pod) from %d of %d live nodes via CLUSTER FORGET", dead.ID, forgotten, len(clusterNodes)))
+		// Coverage is re-derived from fresh views next reconcile, once every
+		// node has dropped the dead entries.
+		return &ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 
+	uncovered := internalValkey.UncoveredSlotRanges(views)
+	if len(uncovered) == 0 {
+		return nil, nil
+	}
+
+	var target *internalValkey.ClusterNode
+	for _, cn := range clusterNodes {
+		if cn.IsMaster() {
+			target = cn
+			break
+		}
+	}
+	if target == nil {
+		return nil, fmt.Errorf("no live primary to assign %d uncovered slot ranges to", len(uncovered))
+	}
+	targetClient, err := r.NewValkeyClient(ctx, valkeyCluster, target.IP, VALKEY_PORT)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create valkey client for slot coverage on pod %s: %w", target.Pod, err)
+	}
+	defer targetClient.Close()
+	slotCount := 0
+	for _, sr := range uncovered {
+		logger.Info("Assigning uncovered slots to live primary",
+			"pod", target.Pod,
+			"start", sr.Start,
+			"end", sr.End)
+		err := targetClient.Do(ctx, targetClient.B().ClusterAddslotsrange().StartSlotEndSlot().StartSlotEndSlot(int64(sr.Start), int64(sr.End)).Build()).Error()
+		if err != nil {
+			return nil, fmt.Errorf("failed to assign uncovered slots %d-%d to pod %s: %w", sr.Start, sr.End, target.Pod, err)
+		}
+		slotCount += sr.End - sr.Start + 1
+	}
+	r.Recorder.Event(valkeyCluster, "Warning", "SlotCoverageRestored",
+		fmt.Sprintf("Assigned %d slots owned by no live node to %s; data in those slots is lost", slotCount, target.Pod))
 	return &ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 }

--- a/internal/controller/valkeycluster_controller_job.go
+++ b/internal/controller/valkeycluster_controller_job.go
@@ -157,9 +157,13 @@ func (m *ValkeyJobManager) FixClusterSlots(ctx context.Context, valkeyCluster *c
 		return fmt.Errorf("Failed to get target pod address: %w", err)
 	}
 
+	// --cluster-yes: fix prompts for confirmation when covering uncovered
+	// slots, and a Job pod has no stdin — without it valkey-cli blocks on the
+	// prompt forever.
 	args := []string{
 		"--cluster", "fix", targetAddress,
 		"--cluster-fix-with-unreachable-primaries",
+		"--cluster-yes",
 	}
 
 	stdout, stderr, err := m.reconciler.executeValkeyCliJob(ctx, valkeyCluster, args)

--- a/test/e2e/e2e_config_test.go
+++ b/test/e2e/e2e_config_test.go
@@ -289,7 +289,7 @@ spec:
 
 		By("waiting for the ConfigValueRejected warning event")
 		verifyEvent := func() error {
-			return eventWithReasonExists("ConfigValueRejected")
+			return eventWithReasonExists(configClusterName, "ConfigValueRejected")
 		}
 		EventuallyWithOffset(1, verifyEvent, 2*time.Minute, 5*time.Second).Should(Succeed())
 
@@ -375,16 +375,13 @@ spec:
 })
 
 // expectedManagedDefaults mirrors the derivation in the README's
-// "Operator-managed defaults" table: repl-backlog-size clamp(memory/16,
-// 10MiB, 512MiB) and a replica client-output-buffer-limit of clamp(memory/2,
-// 64MiB, 4GiB) hard / hard/2 soft.
+// "Operator-managed defaults" table: a replica client-output-buffer-limit of
+// min(memory/2, 4GiB) hard / hard/2 soft, and repl-backlog-size
+// min(clamp(memory/16, 10MiB, 512MiB), hard).
 func expectedManagedDefaults(memoryLimitBytes int64) (backlog, hard, soft int64) {
-	clamp := func(v, lo, hi int64) int64 {
-		return min(max(v, lo), hi)
-	}
-	backlog = clamp(memoryLimitBytes/16, 10*1024*1024, 512*1024*1024)
-	hard = clamp(memoryLimitBytes/2, 64*1024*1024, 4*1024*1024*1024)
+	hard = min(memoryLimitBytes/2, 4*1024*1024*1024)
 	soft = hard / 2
+	backlog = min(max(memoryLimitBytes/16, 10*1024*1024), 512*1024*1024, hard)
 	return backlog, hard, soft
 }
 
@@ -506,12 +503,12 @@ func configMapContains(expected ...string) error {
 	return nil
 }
 
-// eventWithReasonExists reports whether the config test cluster has emitted
-// an event with the given reason.
-func eventWithReasonExists(reason string) error {
+// eventWithReasonExists reports whether the named cluster has emitted an
+// event with the given reason.
+func eventWithReasonExists(clusterName, reason string) error {
 	cmd := exec.Command("kubectl", "get", "events",
 		"-n", namespace,
-		"--field-selector", fmt.Sprintf("reason=%s,involvedObject.name=%s", reason, configClusterName),
+		"--field-selector", fmt.Sprintf("reason=%s,involvedObject.name=%s", reason, clusterName),
 		"-o", "go-template={{ range .items }}{{ .reason }}{{ \"\\n\" }}{{ end }}",
 	)
 	output, err := utils.Run(cmd)
@@ -519,7 +516,7 @@ func eventWithReasonExists(reason string) error {
 		return fmt.Errorf("received error getting events: %w", err)
 	}
 	if len(utils.GetNonEmptyLines(string(output))) == 0 {
-		return fmt.Errorf("expected an event with reason %s for %s", reason, configClusterName)
+		return fmt.Errorf("expected an event with reason %s for %s", reason, clusterName)
 	}
 	return nil
 }

--- a/test/e2e/e2e_deadnode_test.go
+++ b/test/e2e/e2e_deadnode_test.go
@@ -166,12 +166,12 @@ spec:
 		}
 		EventuallyWithOffset(1, verifyReplacement, 5*time.Minute, 10*time.Second).Should(Succeed())
 
-		By("waiting for the operator to take over the dead node's slots and forget it")
-		EventuallyWithOffset(1, func() error {
-			return eventWithReasonExists(deadNodeClusterName, "DeadNodeSlotTakeover")
-		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		By("waiting for the operator to forget the dead node and restore slot coverage")
 		EventuallyWithOffset(1, func() error {
 			return eventWithReasonExists(deadNodeClusterName, "DeadNodeForgotten")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		EventuallyWithOffset(1, func() error {
+			return eventWithReasonExists(deadNodeClusterName, "SlotCoverageRestored")
 		}, 3*time.Minute, 10*time.Second).Should(Succeed())
 
 		By("waiting for the cluster to fully converge with the dead node gone")

--- a/test/e2e/e2e_deadnode_test.go
+++ b/test/e2e/e2e_deadnode_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/halter/valkey-cluster-operator/test/utils"
+)
+
+// Three shards, no replicas: FAIL promotion needs a majority of slot-holding
+// masters (2 shards can never hard-fail a dead master), and without replicas
+// no auto-failover can preempt the operator's slot-takeover path.
+const (
+	deadNodeClusterName   = "valkeycluster-deadnode"
+	deadNodeClusterShards = 3
+)
+
+var _ = Describe("dead node recovery", Ordered, func() {
+	BeforeAll(func() {
+		By("creating manager namespace")
+		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		_, _ = utils.Run(cmd)
+
+		By("installing CRDs")
+		cmd = exec.Command("make", "install")
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("deploying the controller-manager")
+		projectimage := "valkey-cluster-operator:latest"
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+		_, err = utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("waiting for controller-manager to be ready")
+		verifyControllerUp := func() error {
+			cmd = exec.Command("kubectl", "get",
+				"pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", namespace,
+			)
+			podOutput, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			podNames := utils.GetNonEmptyLines(string(podOutput))
+			if len(podNames) != 1 {
+				return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
+			}
+			cmd = exec.Command("kubectl", "get",
+				"pods", podNames[0], "-o", "jsonpath={.status.phase}",
+				"-n", namespace,
+			)
+			status, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			if string(status) != "Running" {
+				return fmt.Errorf("controller pod in %s status", status)
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyControllerUp, time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		By("cleaning up dead-node test resources")
+		cmd := exec.Command("kubectl", "delete", "--timeout=30s", "valkeycluster", deadNodeClusterName,
+			"-n", namespace,
+		)
+		_, _ = utils.Run(cmd)
+
+		cmd = exec.Command("kubectl", "delete", "--timeout=30s", "pvc",
+			"-l", fmt.Sprintf("cache/name=%s", deadNodeClusterName),
+			"-n", namespace,
+		)
+		_, _ = utils.Run(cmd)
+
+		cmd = exec.Command("kubectl", "delete", "--timeout=10s", "deployment", "valkey-cluster-operator-controller-manager",
+			"-n", namespace,
+		)
+		_, _ = utils.Run(cmd)
+	})
+
+	It("should recover slots owned by a node whose pod and PVC were deleted", func() {
+		By("creating a 3-shard cluster without replicas")
+		cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", "-")
+		cmd.Stdin = strings.NewReader(fmt.Sprintf(`apiVersion: cache.halter.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  image: valkey-server:8.0.5
+  shards: %d
+  replicas: 0
+  minReadySeconds: 5
+  resources:
+    limits:
+      cpu: "0.4"
+      memory: 314Mi
+    requests:
+      cpu: "0.2"
+      memory: 214Mi
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+    storageClassName: standard
+  initialDelaySeconds: 5
+`, deadNodeClusterName, deadNodeClusterShards))
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("waiting for the cluster to be ready")
+		EventuallyWithOffset(1, verifyClusterState(deadNodeClusterName, deadNodeClusterShards, 0, ""), 3*time.Minute, 15*time.Second).Should(Succeed())
+
+		victimPod := deadNodeClusterName + "-1-0"
+		deadNodeID, err := podClusterMyID(victimPod)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		ExpectWithOffset(1, deadNodeID).To(HaveLen(40))
+
+		By("deleting the pod together with its PVC so the replacement joins with a fresh node ID")
+		cmd = exec.Command("kubectl", "-n", namespace, "delete", "pvc", "valkey-data-"+victimPod, "--wait=false")
+		_, err = utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		cmd = exec.Command("kubectl", "-n", namespace, "delete", "pod", victimPod, "--wait=false")
+		_, err = utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("waiting for the replacement pod to come up with a new node ID")
+		verifyReplacement := func() error {
+			newID, err := podClusterMyID(victimPod)
+			if err != nil {
+				return err
+			}
+			if newID == deadNodeID {
+				return fmt.Errorf("pod %s still has node ID %s", victimPod, deadNodeID)
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyReplacement, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("waiting for the operator to take over the dead node's slots and forget it")
+		EventuallyWithOffset(1, func() error {
+			return eventWithReasonExists(deadNodeClusterName, "DeadNodeSlotTakeover")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		EventuallyWithOffset(1, func() error {
+			return eventWithReasonExists(deadNodeClusterName, "DeadNodeForgotten")
+		}, 3*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("waiting for the cluster to fully converge with the dead node gone")
+		verifyRecovered := func() error {
+			if err := verifyClusterState(deadNodeClusterName, deadNodeClusterShards, 0, "")(); err != nil {
+				return err
+			}
+			cmd := exec.Command("kubectl", "get",
+				"pods", "-l", fmt.Sprintf("cache/name=%s", deadNodeClusterName),
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", namespace,
+			)
+			podOutput, err := utils.Run(cmd)
+			if err != nil {
+				return fmt.Errorf("received error getting pods: %w", err)
+			}
+			for _, pod := range utils.GetNonEmptyLines(string(podOutput)) {
+				cmd = exec.Command("kubectl", "-n", namespace, "exec", pod, "-c", "valkey-cluster-node", "--",
+					"valkey-cli", "cluster", "nodes")
+				clusterNodesTxt, _, err := utils.RunWithSplitOutput(cmd)
+				if err != nil {
+					return fmt.Errorf("received error running kubectl exec: %w", err)
+				}
+				if strings.Contains(string(clusterNodesTxt), deadNodeID) {
+					return fmt.Errorf("pod %s still lists dead node %s: %s", pod, deadNodeID, clusterNodesTxt)
+				}
+				if strings.Contains(string(clusterNodesTxt), "fail") {
+					return fmt.Errorf("pod %s still lists a failed node: %s", pod, clusterNodesTxt)
+				}
+			}
+			return nil
+		}
+		EventuallyWithOffset(1, verifyRecovered, 8*time.Minute, 15*time.Second).Should(Succeed())
+	})
+})
+
+func podClusterMyID(podName string) (string, error) {
+	cmd := exec.Command("kubectl", "-n", namespace, "exec", podName, "-c", "valkey-cluster-node", "--",
+		"valkey-cli", "cluster", "myid")
+	stdout, _, err := utils.RunWithSplitOutput(cmd)
+	if err != nil {
+		return "", fmt.Errorf("received error running CLUSTER MYID on pod %s: %w", podName, err)
+	}
+	return strings.TrimSpace(string(stdout)), nil
+}


### PR DESCRIPTION
## Problem

Three gaps in the operator's failure handling:

1. **Dead nodes wedge the cluster permanently.** When a pod and its PVC are deleted together, the replacement pod joins with a fresh node ID while the old ID lingers in CLUSTER NODES — possibly still owning slots. Nothing recovered from this: slot totals never sum to 16384 so resharding requeues forever (`ErrSlotsMigrationInFlight`), initial slot assignment fails with "slot already busy" against the dead owner, and replication setup errors on shards with no slot-holding primary.
2. **The pre-stop hook waits unboundedly and fails silently.** The failover wait loop had no bound and was followed by a 15s sleep, so the kubelet killed the hook mid-loop at the default 30s termination grace period. All skip paths (not master, no connected replicas, replica offline — the case where slots go unavailable) exited silently, because the kubelet discards hook output.
3. **Fleet defaults could exceed the pod's memory.** The 64MiB replica hard-limit floor let a single replica buffer consume the entire pod on small caches (a 64Mi pod got a 64Mi hard limit). And live apply sized buffers from the CR spec, so raising `spec.resources` immediately `CONFIG SET` buffers sized for the new limit onto pods still running with the old one — the exact OOM the sizing exists to avoid.

## Changes

### Dead-node remediation
- `FindDeadNodes` (unit-tested) selects topology entries carrying the hard `fail` flag (not the unconfirmed `fail?`) whose node ID no live pod answers for.
- `remediateDeadNodes` runs before slot assignment and replication setup, and acts only when every existing pod is ready and represented in the live node set — a restarting pod keeps its node ID via its PVC and must never be misread as dead. It is skipped while a valkey-cli Job is running so it cannot act on a topology snapshot taken mid-reshard.
- Remediation uses plain cluster commands (`valkey-cli --cluster fix` is unusable here: its slot-coverage prompt deliberately ignores `--cluster-yes`, so a Job pod without stdin hangs or aborts). One idempotent step per reconcile, so any partial state converges:
  1. a surviving replica of a dead node is promoted with `CLUSTER FAILOVER TAKEOVER` (data preserved);
  2. the dead ID is `CLUSTER FORGET`-ed on every live node ("Unknown node" counts as done), with per-node rejections retried on later reconciles;
  3. a coverage sweep — derived from every live node's view, not just one — assigns slots owned by nobody to a live primary via `CLUSTER ADDSLOTSRANGE` (`SlotCoverageRestored` event; the sweep also heals states left behind by interrupted earlier attempts), and the resharding planner then rebalances.

### Pre-stop hook
- Failover wait capped at 10s, drain sleep reduced 15s → 10s, keeping the whole hook inside the default 30s grace period.
- Skip, timeout, initiation, and completion messages are mirrored to the container's stdout via `/proc/1/fd/1` (visible in `kubectl logs`) plus the on-disk log. Ships via the ConfigMap directory mount — reaches running pods without restarts.

### Fleet default sizing
- Replica hard limit is now `min(memory/2, 4GiB)`; `repl-backlog-size` is additionally capped at the hard limit (valkey ignores a replica hard limit below the backlog). Values for pods ≥ 128Mi are unchanged.
- Live apply derives the sized defaults from each pod's actual `valkey-cluster-node` container memory limit, falling back to spec when the pod carries none. The rendered config file still sizes from spec: pods only boot from it after being recreated from the current template.
- README defaults table updated.

## Testing

- New unit tests: `FindDeadNodes` (dead master with slots, dead replica, live fail-flagged node excluded, `fail?` excluded), tiny-pod sizing (64Mi), per-pod live-apply sizing (pod limit wins over spec, spec fallback, spec parameter override).
- New e2e Describe "dead node recovery": a 3-shard, 0-replica cluster (FAIL promotion needs a majority of slot-holding masters, so 2 shards can never hard-fail a dead node; 0 replicas keeps auto-failover from preempting the slot-takeover path) has one shard's pod deleted together with its PVC, so the replacement joins with a fresh node ID while the old ID lingers owning 5461 slots. Asserts the `DeadNodeForgotten` and `SlotCoverageRestored` events fire and the cluster converges back to full slot coverage with the dead ID absent from every node's view. Verified locally in kind (passes in ~134s). The replica-takeover branch is not e2e-covered: it only triggers when valkey's own failover doesn't, which has no deterministic e2e setup.
- `go build ./...` and `go test ./internal/...` pass; golangci-lint (halter config) introduces no new issues over the baseline.
- The dead-node spec was run locally against kind and passes; the rest of the suite is covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

